### PR TITLE
Fixes for token refresh

### DIFF
--- a/MHVLib/Connection/MHVConnection.m
+++ b/MHVLib/Connection/MHVConnection.m
@@ -33,6 +33,7 @@
 #import "MHVSessionCredentialClientProtocol.h"
 #import "MHVPlatformClient.h"
 #import "MHVPersonClient.h"
+#import "MHVValidator.h"
 
 static NSString *const kCorrelationIdContextKey = @"WC_CorrelationId";
 static NSString *const kResponseIdContextKey = @"WC_ResponseId";
@@ -139,7 +140,8 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 - (void)authenticateWithViewController:(UIViewController *_Nullable)viewController
                             completion:(void(^_Nullable)(NSError *_Nullable error))completion;
 {
-    NSAssert(NO, @"Subclasses must implement %@", NSStringFromSelector(_cmd));
+    NSString *message = [NSString stringWithFormat:@"Subclasses must implement %@", NSStringFromSelector(_cmd)];\
+    MHVASSERT_MESSAGE(message);
 }
 
 - (id<MHVPersonClientProtocol> _Nullable)personClient;
@@ -260,9 +262,10 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
     }
 }
 
-- (void)refreshSessionCredential:(BOOL)forceRefresh completion:(void(^_Nullable)(NSError *_Nullable error))completion
+- (void)refreshSessionCredentialWithCompletion:(void(^_Nullable)(NSError *_Nullable error))completion
 {
-    NSAssert(NO, @"Subclasses must implement %@", NSStringFromSelector(_cmd));
+    NSString *message = [NSString stringWithFormat:@"Subclasses must implement %@", NSStringFromSelector(_cmd)];\
+    MHVASSERT_MESSAGE(message);
 }
 
 - (void)refreshTokenAndReissueRequest:(MHVMethodRequest *)request
@@ -276,7 +279,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
             return;
         }
         
-        [self refreshSessionCredential:YES completion:^(NSError * _Nullable error)
+        [self refreshSessionCredentialWithCompletion:^(NSError * _Nullable error)
         {
             dispatch_async(self.completionQueue, ^
             {

--- a/MHVLib/Connection/MHVConnection.m
+++ b/MHVLib/Connection/MHVConnection.m
@@ -134,13 +134,12 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 
 - (void)getPersonInfoWithCompletion:(void (^_Nonnull)(MHVPersonInfo *_Nullable, NSError *_Nullable error))completion;
 {
-    
 }
 
 - (void)authenticateWithViewController:(UIViewController *_Nullable)viewController
                             completion:(void(^_Nullable)(NSError *_Nullable error))completion;
 {
-    
+    NSAssert(NO, @"Subclasses must implement %@", NSStringFromSelector(_cmd));
 }
 
 - (id<MHVPersonClientProtocol> _Nullable)personClient;
@@ -261,6 +260,11 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
     }
 }
 
+- (void)refreshSessionCredential:(BOOL)forceRefresh completion:(void(^_Nullable)(NSError *_Nullable error))completion
+{
+    NSAssert(NO, @"Subclasses must implement %@", NSStringFromSelector(_cmd));
+}
+
 - (void)refreshTokenAndReissueRequest:(MHVMethodRequest *)request
 {
     dispatch_async(self.completionQueue, ^
@@ -272,7 +276,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
             return;
         }
         
-        [self.credentialClient getSessionCredentialWithCompletion:^(MHVSessionCredential * _Nullable credential, NSError * _Nullable error)
+        [self refreshSessionCredential:YES completion:^(NSError * _Nullable error)
         {
             dispatch_async(self.completionQueue, ^
             {

--- a/MHVLib/Connection/MHVSodaConnection.m
+++ b/MHVLib/Connection/MHVSodaConnection.m
@@ -105,7 +105,7 @@ static NSString *const kPersonInfoKey = @"PersonInfo";
                 return;
             }
             
-            [self refreshSessionCredentialWithCompletion:^(NSError * _Nullable error)
+            [self refreshSessionCredential:NO completion:^(NSError * _Nullable error)
             {
                 if (error)
                 {
@@ -378,9 +378,12 @@ static NSString *const kPersonInfoKey = @"PersonInfo";
     }];
 }
 
-- (void)refreshSessionCredentialWithCompletion:(void(^_Nullable)(NSError *_Nullable error))completion
+- (void)refreshSessionCredential:(BOOL)forceRefresh completion:(void(^_Nullable)(NSError *_Nullable error))completion
 {
-    if (self.sessionCredential)
+    self.credentialClient.connection = self;
+    self.credentialClient.sharedSecret = self.applicationCreationInfo.sharedSecret;
+    
+    if (self.sessionCredential && !forceRefresh)
     {
         if (completion)
         {
@@ -389,9 +392,6 @@ static NSString *const kPersonInfoKey = @"PersonInfo";
         
         return;
     }
-    
-    self.credentialClient.connection = self;
-    self.credentialClient.sharedSecret = self.applicationCreationInfo.sharedSecret;
     
     [self.credentialClient getSessionCredentialWithCompletion:^(MHVSessionCredential * _Nullable credential, NSError * _Nullable error)
     {

--- a/MHVLib/Connection/MHVSodaConnection.m
+++ b/MHVLib/Connection/MHVSodaConnection.m
@@ -105,7 +105,7 @@ static NSString *const kPersonInfoKey = @"PersonInfo";
                 return;
             }
             
-            [self refreshSessionCredential:NO completion:^(NSError * _Nullable error)
+            [self refreshSessionCredentialWithCompletion:^(NSError * _Nullable error)
             {
                 if (error)
                 {
@@ -378,20 +378,10 @@ static NSString *const kPersonInfoKey = @"PersonInfo";
     }];
 }
 
-- (void)refreshSessionCredential:(BOOL)forceRefresh completion:(void(^_Nullable)(NSError *_Nullable error))completion
+- (void)refreshSessionCredentialWithCompletion:(void(^_Nullable)(NSError *_Nullable error))completion
 {
     self.credentialClient.connection = self;
     self.credentialClient.sharedSecret = self.applicationCreationInfo.sharedSecret;
-    
-    if (self.sessionCredential && !forceRefresh)
-    {
-        if (completion)
-        {
-            completion(nil);
-        }
-        
-        return;
-    }
     
     [self.credentialClient getSessionCredentialWithCompletion:^(MHVSessionCredential * _Nullable credential, NSError * _Nullable error)
     {

--- a/MHVLib/Transport/MHVRequestMessageCreator.m
+++ b/MHVLib/Transport/MHVRequestMessageCreator.m
@@ -133,7 +133,7 @@
 
 - (void)writeAuthSessionHeader:(NSMutableString *)header
 {
-    if ([NSString isNilOrEmpty:self.authSession.authToken])
+    if ([NSString isNilOrEmpty:self.authSession.authToken] || self.method.isAnonymous)
     {
         NSUUID *appId = self.appId != nil ? self.appId : self.configuration.masterApplicationId;
         


### PR DESCRIPTION
Add forceRefresh to refreshSessionCredential to refresh token.
Don't add authSession header if method is anonymous