### PR TITLE
Update executeMethod to support both Method and Rest operations

### DIFF
--- a/MHVLib.xcodeproj/project.pbxproj
+++ b/MHVLib.xcodeproj/project.pbxproj
@@ -95,6 +95,9 @@
 		4C191AFA1EC3998800B5E545 /* MHVHttpTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C191AF81EC3998800B5E545 /* MHVHttpTask.m */; };
 		4C2975C71ECDFB63006B3673 /* MHVHttpServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C2975C51ECDFB63006B3673 /* MHVHttpServiceTests.m */; };
 		4C2975C81ECDFB63006B3673 /* MHVHttpTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C2975C61ECDFB63006B3673 /* MHVHttpTaskTests.m */; };
+		4C2975EB1ED37AAD006B3673 /* MHVRestRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C2975E91ED37AAD006B3673 /* MHVRestRequest.h */; };
+		4C2975EC1ED37AAD006B3673 /* MHVRestRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C2975EA1ED37AAD006B3673 /* MHVRestRequest.m */; };
+		4C2975EE1ED380F8006B3673 /* MHVHttpServiceOperationProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C2975ED1ED380F8006B3673 /* MHVHttpServiceOperationProtocol.h */; };
 		4C3973B31EC4B66B0079C28D /* MHVLibTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C3973B21EC4B66B0079C28D /* MHVLibTests.m */; };
 		4C7646B81EC4B91C003B85B5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4F066CC1C5C00F000233916 /* SystemConfiguration.framework */; };
 		4C7646B91EC4B922003B85B5 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4F066CE1C5C010800233916 /* MobileCoreServices.framework */; };
@@ -544,8 +547,8 @@
 		A5B384971ECB432400788619 /* MHVRequestMessageCreatorProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B384961ECB432400788619 /* MHVRequestMessageCreatorProtocol.h */; };
 		A5B3849A1ECB4CE400788619 /* MHVAuthSession.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B384981ECB4CE400788619 /* MHVAuthSession.h */; };
 		A5B3849B1ECB4CE400788619 /* MHVAuthSession.m in Sources */ = {isa = PBXBuildFile; fileRef = A5B384991ECB4CE400788619 /* MHVAuthSession.m */; };
-		A5B3849E1ECB741200788619 /* MHVMethodRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B3849C1ECB741200788619 /* MHVMethodRequest.h */; };
-		A5B3849F1ECB741200788619 /* MHVMethodRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A5B3849D1ECB741200788619 /* MHVMethodRequest.m */; };
+		A5B3849E1ECB741200788619 /* MHVHttpServiceRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B3849C1ECB741200788619 /* MHVHttpServiceRequest.h */; };
+		A5B3849F1ECB741200788619 /* MHVHttpServiceRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A5B3849D1ECB741200788619 /* MHVHttpServiceRequest.m */; };
 		A5D1ECEE1EC0FC0A000E3295 /* MHVThingClientProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A5D1ECED1EC0FC0A000E3295 /* MHVThingClientProtocol.h */; };
 		A5D1ED021EC23884000E3295 /* MHVConnectionFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = A5D1ED001EC23884000E3295 /* MHVConnectionFactory.h */; };
 		A5D1ED031EC23884000E3295 /* MHVConnectionFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D1ED011EC23884000E3295 /* MHVConnectionFactory.m */; };
@@ -788,6 +791,9 @@
 		4C191AF81EC3998800B5E545 /* MHVHttpTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MHVHttpTask.m; sourceTree = "<group>"; };
 		4C2975C51ECDFB63006B3673 /* MHVHttpServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MHVHttpServiceTests.m; path = HTTP/MHVHttpServiceTests.m; sourceTree = "<group>"; };
 		4C2975C61ECDFB63006B3673 /* MHVHttpTaskTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MHVHttpTaskTests.m; path = HTTP/MHVHttpTaskTests.m; sourceTree = "<group>"; };
+		4C2975E91ED37AAD006B3673 /* MHVRestRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MHVRestRequest.h; sourceTree = "<group>"; };
+		4C2975EA1ED37AAD006B3673 /* MHVRestRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MHVRestRequest.m; sourceTree = "<group>"; };
+		4C2975ED1ED380F8006B3673 /* MHVHttpServiceOperationProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MHVHttpServiceOperationProtocol.h; path = MHVLib/Methods/MHVHttpServiceOperationProtocol.h; sourceTree = SOURCE_ROOT; };
 		4C3973B01EC4B66B0079C28D /* MHVLibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MHVLibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C3973B21EC4B66B0079C28D /* MHVLibTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MHVLibTests.m; sourceTree = "<group>"; };
 		4C3973B41EC4B66B0079C28D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1245,8 +1251,8 @@
 		A5B384961ECB432400788619 /* MHVRequestMessageCreatorProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MHVRequestMessageCreatorProtocol.h; sourceTree = "<group>"; };
 		A5B384981ECB4CE400788619 /* MHVAuthSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MHVAuthSession.h; sourceTree = "<group>"; };
 		A5B384991ECB4CE400788619 /* MHVAuthSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MHVAuthSession.m; sourceTree = "<group>"; };
-		A5B3849C1ECB741200788619 /* MHVMethodRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MHVMethodRequest.h; sourceTree = "<group>"; };
-		A5B3849D1ECB741200788619 /* MHVMethodRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MHVMethodRequest.m; sourceTree = "<group>"; };
+		A5B3849C1ECB741200788619 /* MHVHttpServiceRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MHVHttpServiceRequest.h; sourceTree = "<group>"; };
+		A5B3849D1ECB741200788619 /* MHVHttpServiceRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MHVHttpServiceRequest.m; sourceTree = "<group>"; };
 		A5D1ECED1EC0FC0A000E3295 /* MHVThingClientProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MHVThingClientProtocol.h; sourceTree = "<group>"; };
 		A5D1ED001EC23884000E3295 /* MHVConnectionFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MHVConnectionFactory.h; sourceTree = "<group>"; };
 		A5D1ED011EC23884000E3295 /* MHVConnectionFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MHVConnectionFactory.m; sourceTree = "<group>"; };
@@ -2002,6 +2008,7 @@
 		5D983BB514E58EE400C287B7 /* Methods */ = {
 			isa = PBXGroup;
 			children = (
+				4C2975ED1ED380F8006B3673 /* MHVHttpServiceOperationProtocol.h */,
 				5D1BE477156B464400718832 /* MHVBeginBlobPutTask.h */,
 				5D1BE478156B464400718832 /* MHVBeginBlobPutTask.m */,
 				5D1BE47B156B483800718832 /* MHVBlobUploadTask.h */,
@@ -2022,8 +2029,8 @@
 				5D39F9261513A63500208A7B /* MHVMethodCallTask.m */,
 				5DAED4AB18E4BC960048ECBD /* MHVMethodFactory.h */,
 				5DAED4AC18E4BC960048ECBD /* MHVMethodFactory.m */,
-				A5B3849C1ECB741200788619 /* MHVMethodRequest.h */,
-				A5B3849D1ECB741200788619 /* MHVMethodRequest.m */,
+				A5B3849C1ECB741200788619 /* MHVHttpServiceRequest.h */,
+				A5B3849D1ECB741200788619 /* MHVHttpServiceRequest.m */,
 				5DC799941535FF4100193A3B /* MHVMethods.h */,
 				5D195D4C1522527100E109AD /* MHVPutThingsTask.h */,
 				5D195D4D1522527100E109AD /* MHVPutThingsTask.m */,
@@ -2031,6 +2038,8 @@
 				5D091279166EB7A60031F5F9 /* MHVRemoveRecordAuthTask.m */,
 				5D195D641522780600E109AD /* MHVRemoveThingsTask.h */,
 				5D195D651522780700E109AD /* MHVRemoveThingsTask.m */,
+				4C2975E91ED37AAD006B3673 /* MHVRestRequest.h */,
+				4C2975EA1ED37AAD006B3673 /* MHVRestRequest.m */,
 				5DB4206B156C959200E1A473 /* MHVThingBlobUploadTask.h */,
 				5DB4206C156C959200E1A473 /* MHVThingBlobUploadTask.m */,
 				5D9E83711553000000072A0C /* MHVVocabSearcher.h */,
@@ -2442,6 +2451,7 @@
 				4C191AF11EC24C2D00B5E545 /* MHVHttpService.h in Headers */,
 				BA03560E1EC1257F00BE547D /* NSSet+DataModel.h in Headers */,
 				BA0356FF1EC5278800BE547D /* MHVGoalsResponse.h in Headers */,
+				4C2975EE1ED380F8006B3673 /* MHVHttpServiceOperationProtocol.h in Headers */,
 				5DE3830E14E4447800DFA11D /* XException.h in Headers */,
 				4C191AEF1EC24C2D00B5E545 /* MHVHttpServiceResponse.h in Headers */,
 				BA0356F91EC5278800BE547D /* MHVGoalRecommendationInstance.h in Headers */,
@@ -2549,6 +2559,7 @@
 				5D20D35314F487F100160611 /* MHVPendingThing.h in Headers */,
 				4C191AA71EC1033C00B5E545 /* MHVSleepJournalPM.h in Headers */,
 				5D20D35714F4883700160611 /* MHVThingQueryResult.h in Headers */,
+				4C2975EB1ED37AAD006B3673 /* MHVRestRequest.h in Headers */,
 				5DD0B80A14F81DDE00AAD54F /* XSerializableType.h in Headers */,
 				5DC44B7C14FEA3E600E2E02F /* MHVRandom.h in Headers */,
 				BA2637591ECF8C200022D060 /* MHVRemoteMonitoringClientProtocol.h in Headers */,
@@ -2663,7 +2674,7 @@
 				A5AC1F581EC0F93A0049C24D /* MHVPlatformClientProtocol.h in Headers */,
 				A5AC1F571EC0F93A0049C24D /* MHVPersonClientProtocol.h in Headers */,
 				A5D1ECEE1EC0FC0A000E3295 /* MHVThingClientProtocol.h in Headers */,
-				A5B3849E1ECB741200788619 /* MHVMethodRequest.h in Headers */,
+				A5B3849E1ECB741200788619 /* MHVHttpServiceRequest.h in Headers */,
 				A542205B1EC2698F00728913 /* MHVSodaConnection.h in Headers */,
 				A51B6CA31EC4AFE5003BFBDC /* MHVMethod.h in Headers */,
 				5DC799641534C97200193A3B /* MHVOneToFive.h in Headers */,
@@ -2997,6 +3008,7 @@
 				5D20D2DF14EDD5FE00160611 /* MHVPositiveDouble.m in Sources */,
 				5D20D2E314EDD6C100160611 /* MHVWeightMeasurement.m in Sources */,
 				5DAED4AE18E4BC970048ECBD /* MHVMethodFactory.m in Sources */,
+				4C2975EC1ED37AAD006B3673 /* MHVRestRequest.m in Sources */,
 				5D20D2E714EDDEF500160611 /* MHVDisplayValue.m in Sources */,
 				5D20D2EF14EEF84400160611 /* MHVInt.m in Sources */,
 				5D20D2F314EEF99400160611 /* MHVDouble.m in Sources */,
@@ -3016,7 +3028,7 @@
 				5D20D31C14F2FA5900160611 /* MHVThingSection.m in Sources */,
 				5D20D32414F304E700160611 /* MHVThingState.m in Sources */,
 				5DB2E69518D2553B0030972D /* MHVThingChange.m in Sources */,
-				A5B3849F1ECB741200788619 /* MHVMethodRequest.m in Sources */,
+				A5B3849F1ECB741200788619 /* MHVHttpServiceRequest.m in Sources */,
 				5D20D32814F424F000160611 /* MHVThingType.m in Sources */,
 				5D20D32C14F42E1300160611 /* MHVThingData.m in Sources */,
 				5D20D33014F4352A00160611 /* MHVThingDataCommon.m in Sources */,

--- a/MHVLib/Clients/MHVClientFactory.m
+++ b/MHVLib/Clients/MHVClientFactory.m
@@ -20,6 +20,7 @@
 #import "MHVPersonClient.h"
 #import "MHVPlatformClient.h"
 #import "MHVSessionCredentialClient.h"
+#import "MHVThingClient.h"
 
 @implementation MHVClientFactory
 
@@ -35,11 +36,12 @@
 
 - (id<MHVThingClientProtocol>)thingClientWithConnection:(id<MHVConnectionProtocol>)connection
 {
-    return nil;
+    return [[MHVThingClient alloc] initWithConnection:connection];
 }
 
 - (id<MHVVocabularyClientProtocol>)vocabularyClientWithConnection:(id<MHVConnectionProtocol>)connection
 {
+    NSAssert(NO, @"Must Implement");
     return nil;
 }
 

--- a/MHVLib/Clients/MHVClientFactory.m
+++ b/MHVLib/Clients/MHVClientFactory.m
@@ -41,7 +41,6 @@
 
 - (id<MHVVocabularyClientProtocol>)vocabularyClientWithConnection:(id<MHVConnectionProtocol>)connection
 {
-    NSAssert(NO, @"Must Implement");
     return nil;
 }
 

--- a/MHVLib/Clients/MHVPersonClient.m
+++ b/MHVLib/Clients/MHVPersonClient.m
@@ -73,7 +73,8 @@
     MHVMethod *method = [MHVMethod getAuthorizedPeople];
     method.parameters = @"<info><parameters></parameters></info>";
     
-    [self.connection executeMethod:method completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
+    [self.connection executeHttpServiceOperation:method
+                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
     {
         if (error)
         {

--- a/MHVLib/Clients/MHVPlatformClient.m
+++ b/MHVLib/Clients/MHVPlatformClient.m
@@ -105,7 +105,8 @@
         return;
     }
     
-    [self.connection executeMethod:[MHVMethod newApplicationCreationInfo] completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
+    [self.connection executeHttpServiceOperation:[MHVMethod newApplicationCreationInfo]
+                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
     {
         if (error)
         {
@@ -133,7 +134,8 @@
     MHVMethod *method = [MHVMethod removeApplicationRecordAuthorization];
     method.recordId = recordId;
     
-    [self.connection executeMethod:method completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
+    [self.connection executeHttpServiceOperation:method
+                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
     {
         if (completion)
         {
@@ -157,8 +159,8 @@
     MHVMethod *method = [MHVMethod getServiceDefinition];
     method.parameters = parameters;
     
-    [self.connection executeMethod:method
-                        completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
+    [self.connection executeHttpServiceOperation:method
+                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
     {
         if (error)
         {

--- a/MHVLib/Clients/MHVRemoteMonitoringClient.h
+++ b/MHVLib/Clients/MHVRemoteMonitoringClient.h
@@ -19,10 +19,13 @@
 
 #import <Foundation/Foundation.h>
 #import "MHVRemoteMonitoringClientProtocol.h"
+@protocol MHVConnectionProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MHVRemoteMonitoringClient : NSObject<MHVRemoteMonitoringClientProtocol>
+
+- (instancetype)initWithConnection:(id<MHVConnectionProtocol>)connection;
 
 @end
 

--- a/MHVLib/Clients/MHVRemoteMonitoringClient.m
+++ b/MHVLib/Clients/MHVRemoteMonitoringClient.m
@@ -18,61 +18,109 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "MHVCommon.h"
 #import "MHVRemoteMonitoringClient.h"
 #import "MHVClient.h"
 #import "MHVJsonSerializer.h"
+#import "MHVConnectionProtocol.h"
+#import "MHVRestRequest.h"
+#import "MHVServiceResponse.h"
+#import "MHVConnectionFactory.h"
+#import "MHVConnection.h"
+
+@interface MHVRemoteMonitoringClient ()
+
+@property (nonatomic, weak) id<MHVConnectionProtocol>     connection;
+
+@end
 
 @implementation MHVRemoteMonitoringClient
 
-+ (NSURLSessionTask*) requestWithPath:(NSString* _Nonnull)path
-                               method:(NSString* _Nonnull)method
-                           pathParams:(NSDictionary * _Nullable)pathParams
-                          queryParams:(NSDictionary* _Nullable)queryParams
-                           formParams:(NSDictionary * _Nullable)formParams
-                                 body:(id _Nullable)body
-                              toClass:(Class)toClass
-                           completion:(void (^ _Nonnull)(id _Nullable output, NSError * _Nullable error))completion
+- (instancetype)initWithConnection:(id<MHVConnectionProtocol>)connection
 {
+    MHVASSERT_PARAMETER(connection);
+    
+    self = [super init];
+    if (self)
+    {
+        _connection = connection;
+    }
+    
+    return self;
+}
+
+//PENDING: Swagger generated code needs to update to be injected with RemoteMonitoringClient & remove this method
++ (NSURLSessionTask *)requestWithPath:(NSString *_Nonnull)path
+                               method:(NSString *_Nonnull)method
+                           pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+                          queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                           formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
+                                 body:(NSData *_Nullable)body
+                              toClass:(Class)toClass
+                           completion:(void(^_Nonnull)(id _Nullable output, NSError *_Nullable error))completion
+{
+    //    [[MHVRemoteMonitoringClient current] requestWithPath:path
+    //                                              method:method
+    //                                           pathParams:pathParams
+    //                                         queryParams:queryParams
+    //                                          formParams:formParams
+    //                                                body:body
+    //                                             toClass:toClass
+    //                                          completion:completion];
+    
+    return nil;
+}
+
+- (void)requestWithPath:(NSString *_Nonnull)path
+                 method:(NSString *_Nonnull)method
+             pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+            queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+             formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
+                   body:(NSData *_Nullable)body
+                toClass:(Class)toClass
+             completion:(void(^_Nonnull)(id _Nullable output, NSError *_Nullable error))completion
+{
+    if (!completion)
+    {
+        return;
+    }
+    
     if (pathParams != nil)
     {
-        NSMutableString * queryPath = [NSMutableString stringWithString:path];
+        NSMutableString *queryPath = [NSMutableString stringWithString:path];
         
-        [pathParams enumerateKeysAndObjectsUsingBlock:^(id _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop)
-        {
-            [queryPath replaceCharactersInRange:[queryPath rangeOfString:[NSString stringWithFormat:@"{%@}", key]] withString:obj];
-        }];
+        [pathParams enumerateKeysAndObjectsUsingBlock:^(id _Nonnull key, id _Nonnull obj, BOOL *_Nonnull stop)
+         {
+             [queryPath replaceCharactersInRange:[queryPath rangeOfString:[NSString stringWithFormat:@"{%@}", key]] withString:obj];
+         }];
         
         path = [queryPath toString];
     }
     
-    NSString *endpoint = [NSString stringWithFormat:@"https://hvc-prerel-khvwus01.westus2.cloudapp.azure.com%@", path];
+    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:path
+                                                                method:method
+                                                            pathParams:pathParams
+                                                           queryParams:queryParams
+                                                            formParams:formParams
+                                                                  body:body
+                                                           isAnonymous:NO];
     
-    NSURL *url = [NSURL URLWithString:endpoint];
-    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
-    headers[@"Authorization"] = @"TOKEN";
-     
-    [[MHVClient current].service.httpService sendRequestForURL:url body:nil headers:headers completion:^(MHVHttpServiceResponse * _Nullable response, NSError * _Nullable error)
-    {
-        if (!error)
-        {
-            if (!response.hasError)
-            {
-                NSString *body = response.responseAsString;
-                id result = [MHVJsonSerializer deserialize:body toClass:[toClass class] shouldCache:NO];
-                completion(result, error);
-            }
-            else
-            {
-                completion(nil, error);
-            }
-        }
-        else
-        {
-            completion(nil, error);
-        }
+    [self.connection executeMethod:restRequest
+                        completion:^(MHVServiceResponse *_Nullable response, NSError *_Nullable error)
+     {
+         if (error)
+         {
+             completion(nil, error);
+         }
+         else
+         {
+             id result = [MHVJsonSerializer deserialize:response.responseAsString
+                                                toClass:[toClass class]
+                                            shouldCache:YES];
+             
+             completion(result, nil);
+         }
      }];
-    
-    return nil;
 }
 
 @end;

--- a/MHVLib/Clients/MHVRemoteMonitoringClientProtocol.h
+++ b/MHVLib/Clients/MHVRemoteMonitoringClientProtocol.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Performs request
  *
  * @param path Request url.
- * @param method Request method, "GET", "POST", "PATCH", etc
+ * @param httpMethod Request method, "GET", "POST", "PATCH", etc
  * @param pathParams Request path parameters.  Values in {brackets} in the path will be replaced by values from this dictionary
  *        pathParams { @"date" : @"2017-05-23" } with path @"endDate={date}" would result in @"endDate=2017-05-23"
  * @param queryParams Request query parameters dictionary
@@ -45,16 +45,16 @@ NS_ASSUME_NONNULL_BEGIN
                            formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
                                  body:(NSData *_Nullable)body
                               toClass:(Class)toClass
-                           completion:(void(^)(id _Nullable output, NSError *_Nullable error))completion;
+                           completion:(void(^_Nullable)(id _Nullable output, NSError *_Nullable error))completion;
 
 - (void)requestWithPath:(NSString *)path
-                 method:(NSString *)method
+             httpMethod:(NSString *)httpMethod
              pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
             queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
              formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
                    body:(NSData *_Nullable)body
                 toClass:(Class)toClass
-             completion:(void(^)(id _Nullable output, NSError *_Nullable error))completion;
+             completion:(void(^_Nullable)(id _Nullable output, NSError *_Nullable error))completion;
 
 @end
 

--- a/MHVLib/Clients/MHVRemoteMonitoringClientProtocol.h
+++ b/MHVLib/Clients/MHVRemoteMonitoringClientProtocol.h
@@ -27,25 +27,34 @@ NS_ASSUME_NONNULL_BEGIN
  * Performs request
  *
  * @param path Request url.
- * @param method Request method.
- * @param pathParams Request path parameters.
- * @param queryParams Request query parameters.
+ * @param method Request method, "GET", "POST", "PATCH", etc
+ * @param pathParams Request path parameters.  Values in {brackets} in the path will be replaced by values from this dictionary
+ *        pathParams { @"date" : @"2017-05-23" } with path @"endDate={date}" would result in @"endDate=2017-05-23"
+ * @param queryParams Request query parameters dictionary
  * @param formParams Request form parameters.
  * @param body Request body.
- * @param toClass the response should be deserialized to.
- * @param completionBlock The block will be executed when the request completed.
+ * @param toClass the class the response should be deserialized to.
+ * @param completion The block will be executed when the request completed.
  *
  * @return The created session task.
  */
-+ (NSURLSessionTask*) requestWithPath:(NSString* _Nonnull)path
-                               method:(NSString* _Nonnull)method
-                           pathParams:(NSDictionary * _Nullable)pathParams
-                          queryParams:(NSDictionary* _Nullable)queryParams
-                           formParams:(NSDictionary * _Nullable)formParams
-                                 body:(id _Nullable)body
++ (NSURLSessionTask *)requestWithPath:(NSString *)path
+                               method:(NSString *)method
+                           pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+                          queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                           formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
+                                 body:(NSData *_Nullable)body
                               toClass:(Class)toClass
-                           completion:(void (^ _Nonnull)(id _Nullable output, NSError * _Nullable error))completion;
+                           completion:(void(^)(id _Nullable output, NSError *_Nullable error))completion;
 
+- (void)requestWithPath:(NSString *)path
+                 method:(NSString *)method
+             pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+            queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+             formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
+                   body:(NSData *_Nullable)body
+                toClass:(Class)toClass
+             completion:(void(^)(id _Nullable output, NSError *_Nullable error))completion;
 
 @end
 

--- a/MHVLib/Clients/MHVThingClient.m
+++ b/MHVLib/Clients/MHVThingClient.m
@@ -152,8 +152,8 @@
     method.recordId = recordId;
     method.parameters = [self bodyForQueryCollection:queries];
     
-    [self.connection executeMethod:method
-                        completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
+    [self.connection executeHttpServiceOperation:method
+                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
      {
          if (error)
          {
@@ -199,7 +199,7 @@
         return;
     }
     
-    MHVThingFilter *filter = [[MHVThingFilter alloc] initWithTypeClass:thingClass];    
+    MHVThingFilter *filter = [[MHVThingFilter alloc] initWithTypeClass:thingClass];
     if (!filter)
     {
         completion(nil, [NSError MVHInvalidParameter:[NSString stringWithFormat:@"%@ not found in HealthVault thing types", NSStringFromClass(thingClass)]]);
@@ -270,15 +270,15 @@
     
     for (MHVThing *thing in things)
     {
-        [thing prepareForNew];        
+        [thing prepareForNew];
     }
     
     MHVMethod *method = [MHVMethod putThings];
     method.recordId = recordId;
     method.parameters = [self bodyForThingCollection:things];
     
-    [self.connection executeMethod:method
-                        completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
+    [self.connection executeHttpServiceOperation:method
+                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
      {
          if (completion)
          {
@@ -335,18 +335,18 @@
         }
         return;
     }
-
+    
     for (MHVThing *thing in things)
     {
         [thing prepareForUpdate];
     }
-
+    
     MHVMethod *method = [MHVMethod putThings];
     method.recordId = recordId;
     method.parameters = [self bodyForThingCollection:things];
     
-    [self.connection executeMethod:method
-                        completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
+    [self.connection executeHttpServiceOperation:method
+                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
      {
          if (completion)
          {
@@ -408,8 +408,8 @@
     method.recordId = recordId;
     method.parameters = [self bodyForThingIdsFromThingCollection:things];
     
-    [self.connection executeMethod:method
-                        completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
+    [self.connection executeHttpServiceOperation:method
+                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
      {
          if (completion)
          {
@@ -439,7 +439,7 @@
             [XSerializer serialize:query withRoot:@"group" toWriter:writer];
         }
     }
-
+    
     [writer writeEndElement];
     
     return [writer newXmlString];

--- a/MHVLib/Connection/MHVConnection.m
+++ b/MHVLib/Connection/MHVConnection.m
@@ -16,11 +16,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MHVCommon.h"
 #import "MHVConnection.h"
-#import "MHVValidator.h"
 #import "MHVAuthSession.h"
 #import "MHVMethod.h"
-#import "MHVStringExtensions.h"
 #import "MHVSessionCredential.h"
 #import "MHVRequestMessageCreatorProtocol.h"
 #import "MHVRequestMessageCreator.h"
@@ -29,13 +28,11 @@
 #import "NSError+MHVError.h"
 #import "MHVErrorConstants.h"
 #import "MHVServiceResponse.h"
-#import "MHVMethodRequest.h"
+#import "MHVHttpServiceRequest.h"
 #import "MHVClientFactory.h"
 #import "MHVApplicationCreationInfo.h"
-#import "MHVPlatformClient.h"
-#import "MHVPersonClient.h"
-#import "MHVValidator.h"
-#import "MHVThingClient.h"
+#import "MHVRestRequest.h"
+#import "MHVHttpServiceResponse.h"
 
 static NSString *const kCorrelationIdContextKey = @"WC_CorrelationId";
 static NSString *const kResponseIdContextKey = @"WC_ResponseId";
@@ -43,7 +40,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 @interface MHVConnection ()
 
 @property (nonatomic, strong) dispatch_queue_t completionQueue;
-@property (nonatomic, strong) NSMutableArray<MHVMethodRequest *> *requests;
+@property (nonatomic, strong) NSMutableArray<MHVHttpServiceRequest *> *requests;
 
 // Clients
 @property (nonatomic, strong) id<MHVPlatformClientProtocol> platformClient;
@@ -90,7 +87,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
     return nil;
 }
 
-- (void)executeMethod:(MHVMethod *_Nonnull)method
+- (void)executeMethod:(id<MHVHttpServiceOperationProtocol> _Nonnull)method
            completion:(void (^_Nullable)(MHVServiceResponse *_Nullable response, NSError *_Nullable error))completion
 {
     MHVASSERT_PARAMETER(method);
@@ -108,7 +105,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
         }
         else
         {
-            [self executeMethodRequest:[[MHVMethodRequest alloc] initWithMethod:method completion:completion]];
+            [self executeHttpServiceRequest:[[MHVHttpServiceRequest alloc] initWithServiceOperation:method completion:completion]];
         }
     });
     
@@ -151,7 +148,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 {
     if (!_thingClient)
     {
-        _thingClient = [[MHVThingClient alloc] initWithConnection:self];
+        _thingClient = [self.clientFactory thingClientWithConnection:self];
     }
     
     return _thingClient;
@@ -164,11 +161,29 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 
 #pragma mark - Private
 
-- (void)executeMethodRequest:(MHVMethodRequest *)request
+- (void)executeHttpServiceRequest:(MHVHttpServiceRequest *)request
+{
+    if ([request.serviceOperation isKindOfClass:[MHVMethod class]])
+    {
+        [self executeMethodRequest:request];
+    }
+    else if ([request.serviceOperation isKindOfClass:[MHVRestRequest class]])
+    {
+        [self executeRestRequest:request];
+    }
+    else
+    {
+        NSString *message = [NSString stringWithFormat:@"ServiceOperation not known: %@", NSStringFromClass([request.serviceOperation class])];
+        MHVASSERT_MESSAGE(message);
+    }
+}
+
+- (void)executeMethodRequest:(MHVHttpServiceRequest *)request
 {
     [self.httpService sendRequestForURL:self.serviceInstance.healthServiceUrl
-                                   body:[self messageForMethod:request.method]
-                                headers:[self headersForMethod:request.method]
+                                 method:nil
+                                   body:[[self messageForMethod:request.serviceOperation] dataUsingEncoding:NSUTF8StringEncoding]
+                                headers:[self headersForMethod:request.serviceOperation]
                              completion:^(MHVHttpServiceResponse * _Nullable response, NSError * _Nullable error)
     {
         if (error)
@@ -191,14 +206,68 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
         }
         else
         {
-            [self parseResponse:response request:request completion:request.completion];
+            [self parseResponse:response request:request isXML:YES completion:request.completion];
         }
-        
     }];
-    
-    
 }
 
+- (void)executeRestRequest:(MHVHttpServiceRequest *)request
+{
+    MHVRestRequest *restRequest = request.serviceOperation;
+    
+    if (restRequest.restRequestType == MHVRestRequestJSON)
+    {
+        [self executeJsonRestRequest:request];
+    }
+}
+
+- (void)executeJsonRestRequest:(MHVHttpServiceRequest *)request
+{
+    MHVRestRequest *restRequest = request.serviceOperation;
+
+    // If no URL is set, build it from serviceInstance
+    if (!restRequest.url)
+    {
+        [restRequest updateUrlWithServiceUrl:self.serviceInstance.healthServiceUrl];
+    }
+    
+    // Add authorization header
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    if (!restRequest.isAnonymous)
+    {
+        headers[@"Authorization"] = self.sessionCredential.token;
+    }
+    
+    [self.httpService sendRequestForURL:restRequest.url
+                                 method:restRequest.method
+                                   body:restRequest.body
+                                headers:headers
+                             completion:^(MHVHttpServiceResponse * _Nullable response, NSError * _Nullable error)
+    {
+        // If unauthorized, refresh token and retry request
+        if (error.code == MHVErrorTypeUnauthorized || response.statusCode == 401)
+        {
+            [self refreshTokenAndReissueRequest:request];
+            
+            return;
+        }
+        
+        if (error)
+        {
+            if (request.completion)
+            {
+                request.completion(nil, error);
+            }
+            
+            return;
+        }
+        else
+        {
+            [self parseResponse:response request:request isXML:NO completion:request.completion];
+        }
+    }];
+}
+    
 - (NSString *)messageForMethod:(MHVMethod *)method
 {
     MHVRequestMessageCreator *creator = [[MHVRequestMessageCreator alloc] initWithMethod:method
@@ -219,7 +288,8 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 }
 
 - (void)parseResponse:(MHVHttpServiceResponse *)response
-              request:(MHVMethodRequest *)request
+              request:(MHVHttpServiceRequest *)request
+                isXML:(BOOL)isXML
            completion:(void (^_Nullable)(MHVServiceResponse *_Nullable response, NSError *_Nullable error))completion
 {
     // If there is no completion, there is no need to parse the response.
@@ -228,7 +298,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
         return;
     }
     
-    MHVServiceResponse *serviceResponse = [[MHVServiceResponse alloc] initWithWebResponse:response];
+    MHVServiceResponse *serviceResponse = [[MHVServiceResponse alloc] initWithWebResponse:response isXML:isXML];
     
     NSError *error = serviceResponse.error;
     
@@ -256,7 +326,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
     MHVASSERT_MESSAGE(message);
 }
 
-- (void)refreshTokenAndReissueRequest:(MHVMethodRequest *)request
+- (void)refreshTokenAndReissueRequest:(MHVHttpServiceRequest *)request
 {
     dispatch_async(self.completionQueue, ^
     {
@@ -273,7 +343,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
             {
                 while (self.requests.count > 0)
                 {
-                    MHVMethodRequest *request = [self.requests firstObject];
+                    MHVHttpServiceRequest *request = [self.requests firstObject];
                     
                     [self.requests removeObject:request];
                     
@@ -288,7 +358,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
                     }
                     else
                     {
-                        [self executeMethodRequest:request];
+                        [self executeHttpServiceRequest:request];
                     }
                 }
             });

--- a/MHVLib/Connection/MHVConnection.m
+++ b/MHVLib/Connection/MHVConnection.m
@@ -156,6 +156,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 
 - (id<MHVVocabularyClientProtocol> _Nullable)vocabularyClient
 {
+    NSAssert(NO, @"Must Implement");
     return nil;
 }
 

--- a/MHVLib/Connection/MHVConnection.m
+++ b/MHVLib/Connection/MHVConnection.m
@@ -87,14 +87,14 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
     return nil;
 }
 
-- (void)executeMethod:(id<MHVHttpServiceOperationProtocol> _Nonnull)method
-           completion:(void (^_Nullable)(MHVServiceResponse *_Nullable response, NSError *_Nullable error))completion
+- (void)executeHttpServiceOperation:(id<MHVHttpServiceOperationProtocol> _Nonnull)operation
+                         completion:(void (^_Nullable)(MHVServiceResponse *_Nullable response, NSError *_Nullable error))completion
 {
-    MHVASSERT_PARAMETER(method);
+    MHVASSERT_PARAMETER(operation);
     
     dispatch_async(self.completionQueue, ^
     {
-        if (!method.isAnonymous && [NSString isNilOrEmpty:self.sessionCredential.token])
+        if (!operation.isAnonymous && [NSString isNilOrEmpty:self.sessionCredential.token])
         {
             if (completion)
             {
@@ -105,7 +105,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
         }
         else
         {
-            [self executeHttpServiceRequest:[[MHVHttpServiceRequest alloc] initWithServiceOperation:method completion:completion]];
+            [self executeHttpServiceRequest:[[MHVHttpServiceRequest alloc] initWithServiceOperation:operation completion:completion]];
         }
     });
     
@@ -156,7 +156,6 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 
 - (id<MHVVocabularyClientProtocol> _Nullable)vocabularyClient
 {
-    NSAssert(NO, @"Must Implement");
     return nil;
 }
 
@@ -182,7 +181,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 - (void)executeMethodRequest:(MHVHttpServiceRequest *)request
 {
     [self.httpService sendRequestForURL:self.serviceInstance.healthServiceUrl
-                                 method:nil
+                             httpMethod:nil
                                    body:[[self messageForMethod:request.serviceOperation] dataUsingEncoding:NSUTF8StringEncoding]
                                 headers:[self headersForMethod:request.serviceOperation]
                              completion:^(MHVHttpServiceResponse * _Nullable response, NSError * _Nullable error)
@@ -216,16 +215,6 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
 {
     MHVRestRequest *restRequest = request.serviceOperation;
     
-    if (restRequest.restRequestType == MHVRestRequestJSON)
-    {
-        [self executeJsonRestRequest:request];
-    }
-}
-
-- (void)executeJsonRestRequest:(MHVHttpServiceRequest *)request
-{
-    MHVRestRequest *restRequest = request.serviceOperation;
-
     // If no URL is set, build it from serviceInstance
     if (!restRequest.url)
     {
@@ -240,7 +229,7 @@ static NSString *const kResponseIdContextKey = @"WC_ResponseId";
     }
     
     [self.httpService sendRequestForURL:restRequest.url
-                                 method:restRequest.method
+                             httpMethod:restRequest.httpMethod
                                    body:restRequest.body
                                 headers:headers
                              completion:^(MHVHttpServiceResponse * _Nullable response, NSError * _Nullable error)

--- a/MHVLib/Connection/MHVConnectionProtocol.h
+++ b/MHVLib/Connection/MHVConnectionProtocol.h
@@ -21,7 +21,7 @@
 
 @class MHVSessionCredential, MHVPersonInfo, MHVServiceResponse, MHVMethod;
 
-@protocol MHVPersonClientProtocol, MHVPlatformClientProtocol, MHVThingClientProtocol, MHVVocabularyClientProtocol;
+@protocol MHVHttpServiceOperationProtocol, MHVPersonClientProtocol, MHVPlatformClientProtocol, MHVThingClientProtocol, MHVVocabularyClientProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param method The method to execute. MHVMethod class has properties representing the method name, version, parameters, recordId and correlationId.
  @para
  */
-- (void)executeMethod:(MHVMethod *)method
+- (void)executeMethod:(id<MHVHttpServiceOperationProtocol>)method
            completion:(void (^_Nullable)(MHVServiceResponse *_Nullable response, NSError *_Nullable error))completion;
 
 /**

--- a/MHVLib/Connection/MHVConnectionProtocol.h
+++ b/MHVLib/Connection/MHVConnectionProtocol.h
@@ -46,13 +46,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly, nullable) MHVPersonInfo *personInfo;
 
 /**
- Makes Web request call to HealthVault service for specified method name and method version.
+ Makes Web request call to HealthVault service.
 
- @param method The method to execute. MHVMethod class has properties representing the method name, version, parameters, recordId and correlationId.
- @para
+ @param operation The operation to execute.  Either MHVMethod or MHVRestRequest.
+        MHVMethod class has properties representing the method name, version, parameters, recordId and correlationId.
+        MHVRestRequest class has properties for url, query parameters, etc.
  */
-- (void)executeMethod:(id<MHVHttpServiceOperationProtocol>)method
-           completion:(void (^_Nullable)(MHVServiceResponse *_Nullable response, NSError *_Nullable error))completion;
+- (void)executeHttpServiceOperation:(id<MHVHttpServiceOperationProtocol>)operation
+                         completion:(void (^_Nullable)(MHVServiceResponse *_Nullable response, NSError *_Nullable error))completion;
 
 /**
  Gets the person information for the current account.

--- a/MHVLib/Connection/MHVSessionCredentialClient.m
+++ b/MHVLib/Connection/MHVSessionCredentialClient.m
@@ -70,8 +70,8 @@
     MHVMethod *method = [MHVMethod createAuthenticatedSessionToken];
     method.parameters = [self infoSectionWithSharedSecret:sharedSecret];
     
-    [self.connection executeMethod:method
-                        completion:^(MHVServiceResponse *_Nullable response, NSError *_Nullable error)
+    [self.connection executeHttpServiceOperation:method
+                                      completion:^(MHVServiceResponse *_Nullable response, NSError *_Nullable error)
     {
         if (error)
         {

--- a/MHVLib/HTTP/MHVHttpService.m
+++ b/MHVLib/HTTP/MHVHttpService.m
@@ -67,14 +67,15 @@
 }
 
 - (id<MHVHttpTaskProtocol>)sendRequestForURL:(NSURL *)url
-                                        body:(NSString *_Nullable)body
+                                        body:(NSData *_Nullable)body
                                   completion:(MHVHttpServiceCompletion)completion
 {
-    return [self sendRequestForURL:url body:body headers:nil completion:completion];
+    return [self sendRequestForURL:url method:nil body:body headers:nil completion:completion];
 }
 
 - (id<MHVHttpTaskProtocol>)sendRequestForURL:(NSURL *)url
-                                        body:(NSString *_Nullable)body
+                                      method:(NSString *_Nullable)method
+                                        body:(NSData *_Nullable)body
                                      headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                                   completion:(MHVHttpServiceCompletion)completion
 {
@@ -95,6 +96,11 @@
     for (NSString *key in headers.allKeys)
     {
         [request setValue:headers[key] forHTTPHeaderField:key];
+    }
+    
+    if (method)
+    {
+        request.HTTPMethod = method;
     }
     
     NSInteger currentRequest = (++self.requestCount);
@@ -319,7 +325,7 @@
 #pragma mark - Internal methods
 
 - (NSURLRequest *)requestWithUrl:(NSURL *)url
-                            body:(NSString *)body
+                            body:(NSData *)body
 {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     
@@ -327,12 +333,10 @@
     
     if (body)
     {
-        NSData *bodyData = [body dataUsingEncoding:NSUTF8StringEncoding];
-        
         request.HTTPMethod = @"POST";
-        request.HTTPBody = bodyData;
+        request.HTTPBody = body;
         
-        [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)bodyData.length] forHTTPHeaderField:@"Content-Length"];
+        [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)body.length] forHTTPHeaderField:@"Content-Length"];
     }
     
     return request;

--- a/MHVLib/HTTP/MHVHttpService.m
+++ b/MHVLib/HTTP/MHVHttpService.m
@@ -70,11 +70,11 @@
                                         body:(NSData *_Nullable)body
                                   completion:(MHVHttpServiceCompletion)completion
 {
-    return [self sendRequestForURL:url method:nil body:body headers:nil completion:completion];
+    return [self sendRequestForURL:url httpMethod:nil body:body headers:nil completion:completion];
 }
 
 - (id<MHVHttpTaskProtocol>)sendRequestForURL:(NSURL *)url
-                                      method:(NSString *_Nullable)method
+                                  httpMethod:(NSString *_Nullable)httpMethod
                                         body:(NSData *_Nullable)body
                                      headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                                   completion:(MHVHttpServiceCompletion)completion
@@ -98,9 +98,9 @@
         [request setValue:headers[key] forHTTPHeaderField:key];
     }
     
-    if (method)
+    if (httpMethod)
     {
-        request.HTTPMethod = method;
+        request.HTTPMethod = httpMethod;
     }
     
     NSInteger currentRequest = (++self.requestCount);

--- a/MHVLib/HTTP/MHVHttpServiceProtocol.h
+++ b/MHVLib/HTTP/MHVHttpServiceProtocol.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  Send a request to HealthVault service
  
  @param url the endpoint for the request
- @param method the method (GET, POST, etc) to use.  nil will use GET, unless there is body which will use POST
+ @param httpMethod the http method (GET, POST, etc) to use.  nil will use GET, unless there is body which will use POST
  @param body data to send as POST body
  @param headers HTTP headers to add to the request for authentication, etc.
  Dictionary key is HTTP header ie "Content-Type"
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return a task that can be cancelled
  */
 - (id<MHVHttpTaskProtocol>)sendRequestForURL:(NSURL *)url
-                                      method:(NSString *_Nullable)method
+                                  httpMethod:(NSString *_Nullable)httpMethod
                                         body:(NSData *_Nullable)body
                                      headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                                   completion:(MHVHttpServiceCompletion)completion;

--- a/MHVLib/HTTP/MHVHttpServiceProtocol.h
+++ b/MHVLib/HTTP/MHVHttpServiceProtocol.h
@@ -38,13 +38,14 @@ NS_ASSUME_NONNULL_BEGIN
  @return a task that can be cancelled
  */
 - (id<MHVHttpTaskProtocol>)sendRequestForURL:(NSURL *)url
-                                        body:(NSString *_Nullable)body
+                                        body:(NSData *_Nullable)body
                                   completion:(MHVHttpServiceCompletion)completion;
 
 /**
  Send a request to HealthVault service
  
  @param url the endpoint for the request
+ @param method the method (GET, POST, etc) to use.  nil will use GET, unless there is body which will use POST
  @param body data to send as POST body
  @param headers HTTP headers to add to the request for authentication, etc.
  Dictionary key is HTTP header ie "Content-Type"
@@ -52,7 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
  @return a task that can be cancelled
  */
 - (id<MHVHttpTaskProtocol>)sendRequestForURL:(NSURL *)url
-                                        body:(NSString *_Nullable)body
+                                      method:(NSString *_Nullable)method
+                                        body:(NSData *_Nullable)body
                                      headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                                   completion:(MHVHttpServiceCompletion)completion;
 

--- a/MHVLib/HVMobile/HealthVaultService.m
+++ b/MHVLib/HVMobile/HealthVaultService.m
@@ -333,7 +333,7 @@
     NSString *requestXml = [request toXml:self];
     
     [self.httpService sendRequestForURL:[NSURL URLWithString:self.healthServiceUrl]
-                                   body:requestXml
+                                   body:[requestXml dataUsingEncoding:NSUTF8StringEncoding]
                              completion:^(MHVHttpServiceResponse * _Nullable response, NSError * _Nullable error)
      {
          [self sendRequestCallback:response

--- a/MHVLib/HVMobile/MHVServiceResponse.h
+++ b/MHVLib/HVMobile/MHVServiceResponse.h
@@ -23,16 +23,23 @@
 @interface MHVServiceResponse : NSObject
 
 // Gets the Http response code...
-@property (assign) int statusCode;
+@property (readonly, nonatomic, assign) int statusCode;
 
-/// Gets or sets the informational part of the response.
-@property (strong) NSString *infoXml;
+/// Gets the informational part of a HealthVault XML response.
+@property (readonly, nonatomic, strong) NSString *infoXml;
 
-@property (nonatomic, strong) NSError *error;
+/// Gets the response as a string
+@property (readonly, nonatomic, strong) NSString *responseAsString;
+
+/// Gets the response as data
+@property (readonly, nonatomic, strong) NSData *responseAsData;
+
+@property (readonly, nonatomic, strong) NSError *error;
 
 /// Initializes a new instance of the HealthVaultResponse class.
 /// @param response - the web response from server side.
+/// @param isXML - if the response is expected to be XML and should be parsed into infoXml
 /// @request - the original request.
-- (instancetype)initWithWebResponse:(MHVHttpServiceResponse *)response;
+- (instancetype)initWithWebResponse:(MHVHttpServiceResponse *)response isXML:(BOOL)isXML;
 
 @end

--- a/MHVLib/HVMobile/MHVServiceResponse.m
+++ b/MHVLib/HVMobile/MHVServiceResponse.m
@@ -34,32 +34,41 @@
 /// Represents that current token has been expired and should be updated.
 #define RESPONSE_AUTH_SESSION_TOKEN_EXPIRED 65
 
+@interface MHVServiceResponse ()
+
+@property (nonatomic, strong) NSError *error;
+@property (nonatomic, strong) NSString *infoXml;
+
+@end
+
 @implementation MHVServiceResponse
 
-- (instancetype)initWithWebResponse:(MHVHttpServiceResponse *)response
+- (instancetype)initWithWebResponse:(MHVHttpServiceResponse *)response isXML:(BOOL)isXML
 {
     self = [super init];
     
     if (self)
     {
         _statusCode = (int)response.statusCode;
+        _responseAsData = response.responseAsData;
+        _responseAsString = response.responseAsString;
         
         if (response.hasError)
         {
             if (_statusCode == 401)
             {
-                self.error = [NSError error:[NSError MHVUnauthorizedError] withDescription:@"The Authorization token is missing, malformed or expired."];
+                _error = [NSError error:[NSError MHVUnauthorizedError] withDescription:@"The Authorization token is missing, malformed or expired."];
             }
         }
-        else
+        else if (isXML)
         {
             NSString *xml = response.responseAsString;
             
-            BOOL xmlReaderesult = [self deserializeXml:xml];
+            BOOL xmlReaderResult = [self deserializeXml:xml];
             
-            if (!xmlReaderesult)
+            if (!xmlReaderResult)
             {
-                self.error = [NSError error:[NSError MHVUnknownError] withDescription:[NSString stringWithFormat:@"Response was not a valid HealthVault response.\n%@",xml]];
+                _error = [NSError error:[NSError MHVUnknownError] withDescription:[NSString stringWithFormat:@"Response was not a valid HealthVault response.\n%@",xml]];
             }
         }
     }

--- a/MHVLib/MHVDictionaryExtensions.h
+++ b/MHVLib/MHVDictionaryExtensions.h
@@ -25,5 +25,7 @@
 // Argument string separated by '&'
 + (NSMutableDictionary *)dictionaryFromArgumentString:(NSString *)qs;
 
+- (NSString *)queryString;
+
 @end
 

--- a/MHVLib/MHVDictionaryExtensions.m
+++ b/MHVLib/MHVDictionaryExtensions.m
@@ -66,4 +66,24 @@
     return nvPairs;
 }
 
+- (NSString *)queryString
+{
+    if (self.allKeys.count == 0)
+    {
+        return @"";
+    }
+    
+    NSMutableString *query = [[NSMutableString alloc] init];
+    
+    for (NSString *key in self.allKeys)
+    {
+        if (query.length > 0)
+        {
+            [query appendString:@"&"];
+        }
+        [query appendFormat:@"%@=%@", key, [self[key] urlEncode]];
+    }
+    return query;
+}
+
 @end

--- a/MHVLib/Methods/MHVHttpServiceOperationProtocol.h
+++ b/MHVLib/Methods/MHVHttpServiceOperationProtocol.h
@@ -1,0 +1,18 @@
+//
+//  MHVHttpServiceOperationProtocol.h
+//  MHVLib
+//
+//  Created by Michael Burford on 5/22/17.
+//  Copyright © 2017 Microsoft Corporation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol MHVHttpServiceOperationProtocol <NSObject>
+
+/**
+ A Boolean representing whether the operation call requires authentication
+ */
+@property (nonatomic, assign, readonly) BOOL isAnonymous;
+
+@end

--- a/MHVLib/Methods/MHVHttpServiceRequest.h
+++ b/MHVLib/Methods/MHVHttpServiceRequest.h
@@ -18,19 +18,21 @@
 
 #import <Foundation/Foundation.h>
 
-@class MHVMethod, MHVServiceResponse;
+@class MHVMethod, MHVServiceResponse, MHVHttpServiceRequest;
+@protocol MHVHttpServiceOperationProtocol;
 
 typedef void (^MHVRequestCompletion)(MHVServiceResponse *_Nullable response, NSError *_Nullable error);
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MHVMethodRequest : NSObject
+@interface MHVHttpServiceRequest : NSObject
 
-@property (nonatomic, strong, readonly) MHVMethod *method;
+@property (nonatomic, strong, readonly) id<MHVHttpServiceOperationProtocol> serviceOperation;
 @property (nonatomic, strong, readonly, nullable) MHVRequestCompletion completion;
 @property (nonatomic, assign) NSInteger retryAttempts;
 
-- (instancetype)initWithMethod:(MHVMethod *)method completion:(MHVRequestCompletion _Nullable)completion;
+- (instancetype)initWithServiceOperation:(id<MHVHttpServiceOperationProtocol>)serviceOperation
+                              completion:(MHVRequestCompletion _Nullable)completion;
 
 @end
 

--- a/MHVLib/Methods/MHVHttpServiceRequest.m
+++ b/MHVLib/Methods/MHVHttpServiceRequest.m
@@ -16,20 +16,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MHVMethodRequest.h"
+#import "MHVHttpServiceRequest.h"
 #import "MHVValidator.h"
 
-@implementation MHVMethodRequest
+@implementation MHVHttpServiceRequest
 
-- (instancetype)initWithMethod:(MHVMethod *)method completion:(MHVRequestCompletion _Nullable)completion
+- (instancetype)initWithServiceOperation:(id<MHVHttpServiceOperationProtocol>)serviceOperation
+                              completion:(MHVRequestCompletion _Nullable)completion
 {
-    MHVASSERT_PARAMETER(method);
+    MHVASSERT_PARAMETER(serviceOperation);
     
     self = [super init];
     
     if (self)
     {
-        _method = method;
+        _serviceOperation = serviceOperation;
         _completion = completion;
         _retryAttempts = 0;
     }

--- a/MHVLib/Methods/MHVMethod.h
+++ b/MHVLib/Methods/MHVMethod.h
@@ -17,20 +17,16 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "MHVHttpServiceOperationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MHVMethod : NSObject
+@interface MHVMethod : NSObject <MHVHttpServiceOperationProtocol>
 
 /**
  The name of the method to be called. Reference at: http://developer.healthvault.com/pages/methods/methods.aspx
  */
 @property (nonatomic, strong, readonly) NSString *name;
-
-/**
- A Boolean representing whether the method call requires authentication
- */
-@property (nonatomic, assign, readonly) BOOL isAnonymous;
 
 /**
  The method version. The version will default to the latest method version at the time of the SDK release.

--- a/MHVLib/Methods/MHVMethod.m
+++ b/MHVLib/Methods/MHVMethod.m
@@ -18,6 +18,12 @@
 
 #import "MHVMethod.h"
 
+@interface MHVMethod ()
+
+@property (nonatomic, assign) BOOL isAnonymous;
+
+@end
+
 @implementation MHVMethod
 
 - (instancetype)initWithName:(NSString *)name version:(int)version isAnonymous:(BOOL)isAnonymous

--- a/MHVLib/Methods/MHVRestRequest.h
+++ b/MHVLib/Methods/MHVRestRequest.h
@@ -1,0 +1,53 @@
+//
+//  MHVRestRequest.h
+//  MHVLib
+//
+//  Created by Michael Burford on 5/22/17.
+//  Copyright © 2017 Microsoft Corporation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "MHVHttpServiceOperationProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, MHVRestRequestType)
+{
+    MHVRestRequestJSON,
+    //MHVRestRequestDownloadBlobData,
+    //MHVRestRequestDownloadBlobFile,
+    //MHVRestRequestUploadBlob,
+};
+
+@interface MHVRestRequest : NSObject <MHVHttpServiceOperationProtocol>
+
+@property (nonatomic, assign, readonly)           MHVRestRequestType restRequestType;
+
+@property (nonatomic, strong, readonly)           NSString      *path;
+@property (nonatomic, strong, readonly)           NSString      *method;
+@property (nonatomic, strong, readonly, nullable) NSDictionary  *pathParams;
+@property (nonatomic, strong, readonly, nullable) NSDictionary  *queryParams;
+@property (nonatomic, strong, readonly, nullable) NSDictionary  *formParams;
+@property (nonatomic, strong, readonly, nullable) id            body;
+@property (nonatomic, assign, readonly)           BOOL          isAnonymous;
+
+@property (nonatomic, strong, readonly)           NSURL         *url;
+
+- (instancetype)initWithPath:(NSString *)path
+                      method:(NSString *)method
+                  pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+                 queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                  formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
+                        body:(NSData *_Nullable)body
+                 isAnonymous:(BOOL)isAnonymous;
+
+- (instancetype)initWithURL:(NSURL *)url
+                     method:(NSString *)method
+                       body:(NSData *_Nullable)body
+                isAnonymous:(BOOL)isAnonymous;
+
+- (void)updateUrlWithServiceUrl:(NSURL *)serviceUrl;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MHVLib/Methods/MHVRestRequest.h
+++ b/MHVLib/Methods/MHVRestRequest.h
@@ -11,20 +11,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, MHVRestRequestType)
-{
-    MHVRestRequestJSON,
-    //MHVRestRequestDownloadBlobData,
-    //MHVRestRequestDownloadBlobFile,
-    //MHVRestRequestUploadBlob,
-};
-
 @interface MHVRestRequest : NSObject <MHVHttpServiceOperationProtocol>
 
-@property (nonatomic, assign, readonly)           MHVRestRequestType restRequestType;
-
 @property (nonatomic, strong, readonly)           NSString      *path;
-@property (nonatomic, strong, readonly)           NSString      *method;
+@property (nonatomic, strong, readonly)           NSString      *httpMethod;
 @property (nonatomic, strong, readonly, nullable) NSDictionary  *pathParams;
 @property (nonatomic, strong, readonly, nullable) NSDictionary  *queryParams;
 @property (nonatomic, strong, readonly, nullable) NSDictionary  *formParams;
@@ -34,7 +24,7 @@ typedef NS_ENUM(NSInteger, MHVRestRequestType)
 @property (nonatomic, strong, readonly)           NSURL         *url;
 
 - (instancetype)initWithPath:(NSString *)path
-                      method:(NSString *)method
+                  httpMethod:(NSString *)httpMethod
                   pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
                  queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
                   formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
@@ -42,7 +32,7 @@ typedef NS_ENUM(NSInteger, MHVRestRequestType)
                  isAnonymous:(BOOL)isAnonymous;
 
 - (instancetype)initWithURL:(NSURL *)url
-                     method:(NSString *)method
+                 httpMethod:(NSString *)httpMethod
                        body:(NSData *_Nullable)body
                 isAnonymous:(BOOL)isAnonymous;
 

--- a/MHVLib/Methods/MHVRestRequest.m
+++ b/MHVLib/Methods/MHVRestRequest.m
@@ -12,7 +12,7 @@
 @implementation MHVRestRequest
 
 - (instancetype)initWithPath:(NSString *)path
-                      method:(NSString *)method
+                  httpMethod:(NSString *)httpMethod
                   pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
                  queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
                   formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
@@ -20,13 +20,13 @@
                  isAnonymous:(BOOL)isAnonymous
 {
     MHVASSERT_PARAMETER(path);
-    MHVASSERT_PARAMETER(method);
+    MHVASSERT_PARAMETER(httpMethod);
     
     self = [super init];
     if (self)
     {
         _path = path;
-        _method = method;
+        _httpMethod = httpMethod;
         _pathParams = pathParams;
         _queryParams = queryParams;
         _formParams = formParams;
@@ -37,18 +37,18 @@
 }
 
 - (instancetype)initWithURL:(NSURL *)url
-                     method:(NSString *)method
+                 httpMethod:(NSString *)httpMethod
                        body:(NSData *_Nullable)body
                 isAnonymous:(BOOL)isAnonymous
 {
     MHVASSERT_PARAMETER(url);
     MHVASSERT_PARAMETER(url);
-
+    
     self = [super init];
     if (self)
     {
         _url = url;
-        _method = method;
+        _httpMethod = httpMethod;
         _body = body;
         _isAnonymous = isAnonymous;
     }
@@ -65,7 +65,7 @@
         _path = [NSString stringWithFormat:@"/%@", _path];
     }
     urlComponents.path = self.path;
-
+    
     urlComponents.query = [self.queryParams queryString];
     
     _url = urlComponents.URL;

--- a/MHVLib/Methods/MHVRestRequest.m
+++ b/MHVLib/Methods/MHVRestRequest.m
@@ -1,0 +1,74 @@
+//
+//  MHVRestRequest.m
+//  MHVLib
+//
+//  Created by Michael Burford on 5/22/17.
+//  Copyright © 2017 Microsoft Corporation. All rights reserved.
+//
+
+#import "MHVCommon.h"
+#import "MHVRestRequest.h"
+
+@implementation MHVRestRequest
+
+- (instancetype)initWithPath:(NSString *)path
+                      method:(NSString *)method
+                  pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+                 queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                  formParams:(NSDictionary<NSString *, NSString *> *_Nullable)formParams
+                        body:(NSData *_Nullable)body
+                 isAnonymous:(BOOL)isAnonymous
+{
+    MHVASSERT_PARAMETER(path);
+    MHVASSERT_PARAMETER(method);
+    
+    self = [super init];
+    if (self)
+    {
+        _path = path;
+        _method = method;
+        _pathParams = pathParams;
+        _queryParams = queryParams;
+        _formParams = formParams;
+        _body = body;
+        _isAnonymous = isAnonymous;
+    }
+    return self;
+}
+
+- (instancetype)initWithURL:(NSURL *)url
+                     method:(NSString *)method
+                       body:(NSData *_Nullable)body
+                isAnonymous:(BOOL)isAnonymous
+{
+    MHVASSERT_PARAMETER(url);
+    MHVASSERT_PARAMETER(url);
+
+    self = [super init];
+    if (self)
+    {
+        _url = url;
+        _method = method;
+        _body = body;
+        _isAnonymous = isAnonymous;
+    }
+    return self;
+}
+
+- (void)updateUrlWithServiceUrl:(NSURL *)serviceUrl
+{
+    NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:serviceUrl resolvingAgainstBaseURL:YES];
+    
+    //Path needs to start with / for NSURLComponents
+    if (![self.path hasPrefix:@"/"])
+    {
+        _path = [NSString stringWithFormat:@"/%@", _path];
+    }
+    urlComponents.path = self.path;
+
+    urlComponents.query = [self.queryParams queryString];
+    
+    _url = urlComponents.URL;
+}
+
+@end

--- a/MHVLib/Models/MHVModelBase.m
+++ b/MHVLib/Models/MHVModelBase.m
@@ -29,6 +29,8 @@ static NSString *kDataModelObjectParametersKey = @"DataModelObjectParametersKey"
 static NSString *kDataModelNameMapKey = @"DataModelNameMapKey";
 static NSString *kClassPrefix = @"MHV";
 
+Class classFromProperty(objc_property_t property);
+
 @implementation MHVModelBase
 
 #pragma mark - DataModel v2

--- a/MHVLibTests/Clients/MHVThingClientTests.m
+++ b/MHVLibTests/Clients/MHVThingClientTests.m
@@ -30,13 +30,13 @@ SPEC_BEGIN(MHVThingClientTests)
 describe(@"MHVThingClient", ^
 {
     KWMock<MHVConnectionProtocol> *mockConnection = [KWMock mockForProtocol:@protocol(MHVConnectionProtocol)];
-    [mockConnection stub:@selector(executeMethod:completion:) andReturn:nil];
+    [mockConnection stub:@selector(executeHttpServiceOperation:completion:) andReturn:nil];
     
     NSUUID *recordId = [[NSUUID alloc] initWithUUIDString:@"20000000-2000-2000-2000-200000000000"];
     
     let(spyExecuteMethod, ^
         {
-            return [mockConnection captureArgument:@selector(executeMethod:completion:) atIndex:0];
+            return [mockConnection captureArgument:@selector(executeHttpServiceOperation:completion:) atIndex:0];
         });
     
     let(thingClient, ^

--- a/MHVLibTests/HTTP/MHVHttpServiceTests.m
+++ b/MHVLibTests/HTTP/MHVHttpServiceTests.m
@@ -56,6 +56,7 @@ describe(@"MHVHttpService", ^
            {
                //Send request
                [service sendRequestForURL:[NSURL URLWithString:@"https://test.com/path"]
+                                   method:nil
                                      body:@"testbody"
                                   headers:@{
                                             @"Header-One" : @"ABC",

--- a/MHVLibTests/HTTP/MHVHttpServiceTests.m
+++ b/MHVLibTests/HTTP/MHVHttpServiceTests.m
@@ -39,7 +39,7 @@ describe(@"MHVHttpService", ^
            {
                //Send request
                [service sendRequestForURL:[NSURL URLWithString:@"https://test.com/path"]
-                                     body:@"testbody"
+                                     body:[@"testbody" dataUsingEncoding:NSUTF8StringEncoding]
                                completion:^(MHVHttpServiceResponse * _Nullable response, NSError * _Nullable error) { }];
 
                //Verify URLRequest values
@@ -56,8 +56,8 @@ describe(@"MHVHttpService", ^
            {
                //Send request
                [service sendRequestForURL:[NSURL URLWithString:@"https://test.com/path"]
-                                   method:nil
-                                     body:@"testbody"
+                               httpMethod:nil
+                                     body:[@"testbody" dataUsingEncoding:NSUTF8StringEncoding]
                                   headers:@{
                                             @"Header-One" : @"ABC",
                                             @"Header-Two" : @"123",


### PR DESCRIPTION
Update executeMethod to support both Method and Rest operations.
MHVHttpServiceRequest can hold either type, can refresh token and retry using common logic in MHVConnection