### PR TITLE
Fix 500 error retry time

### DIFF
--- a/HealthVault/Classes/Configuration/MHVConfigurationConstants.h
+++ b/HealthVault/Classes/Configuration/MHVConfigurationConstants.h
@@ -47,7 +47,7 @@ static NSString *const kDefaultHealthVaultRootUrlString = @"https://platform.hea
 /*
  Default sleep duration in seconds.
  */
-static NSTimeInterval const kDefaultRetryOnInternal500SleepDurationInSeconds = 60;
+static NSTimeInterval const kDefaultRetryOnInternal500SleepDurationInSeconds = 1;
 
 /*
  The default request time to live value.


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/microsoft.health.healthapplicationconfiguration.retryoninternal500sleepseconds.aspx

Default per documentation is 1 second, but got set as 1 minute in OneSDK, which we copied.  I'll fix there and send a PR too.