### PR TITLE
Set user credentials when connection is initialized

### DIFF
--- a/Example/Tests/Clients/MHVThingClientBlobFileTests.m
+++ b/Example/Tests/Clients/MHVThingClientBlobFileTests.m
@@ -47,6 +47,7 @@ describe(@"MHVThingClient", ^
     
     MHVClientFactory *clientFactory = [MHVClientFactory new];
     [(id)keychainService stub:@selector(setXMLObject:forKey:) andReturn:theValue(YES)];
+    [(id)keychainService stub:@selector(xmlObjectForKey:) andReturn:nil];
     
     // Test http service
     MHVHttpService *httpService = [[MHVHttpService alloc] initWithURLSession:urlSession];

--- a/Example/Tests/Connection/MHVConnectionTests.m
+++ b/Example/Tests/Connection/MHVConnectionTests.m
@@ -68,6 +68,7 @@ describe(@"MHVConnectionTests", ^
     [(id)clientFactory stub:@selector(credentialClientWithConnection:) andReturn:credentialClient];
     [(id)clientFactory stub:@selector(personClientWithConnection:) andReturn:personClient];
     [(id)keychainService stub:@selector(setXMLObject:forKey:) andReturn:theValue(YES)];
+     [(id)keychainService stub:@selector(xmlObjectForKey:) andReturn:nil];
     
     MHVConfiguration *configuration = [MHVConfiguration new];
     configuration.retryOnInternal500SleepDuration = 1.0;

--- a/Example/Tests/Connection/MHVSodaConnectionTests.m
+++ b/Example/Tests/Connection/MHVSodaConnectionTests.m
@@ -127,16 +127,6 @@ describe(@"MHVSodaConnection", ^
     
     beforeEach(^
     {
-        // Setup the default state and create a new instance of the connection
-        // The default values setup the authentication flow to a passing state
-        connection = [[MHVSodaConnection alloc] initWithConfiguration:config
-                                                    cacheSynchronizer:nil
-                                                   cacheConfiguration:nil
-                                                        clientFactory:clientFactory
-                                                          httpService:httpservice
-                                                      keychainService:keychainService
-                                                     shellAuthService:authService];
-        
         shouldSaveServiceInstance = YES;
         shouldSaveApplicationCreationInfo = YES;
         shouldSaveSessionCredential = YES;
@@ -180,6 +170,16 @@ describe(@"MHVSodaConnection", ^
         personInfoFromKeychain = nil;
         expectedError = nil;
         errorMessage = nil;
+        
+        // Setup the default state and create a new instance of the connection
+        // The default values setup the authentication flow to a passing state
+        connection = [[MHVSodaConnection alloc] initWithConfiguration:config
+                                                    cacheSynchronizer:nil
+                                                   cacheConfiguration:nil
+                                                        clientFactory:clientFactory
+                                                          httpService:httpservice
+                                                      keychainService:keychainService
+                                                     shellAuthService:authService];
     });
     
     

--- a/HealthVault/Classes/Connection/Private/MHVSodaConnection.m
+++ b/HealthVault/Classes/Connection/Private/MHVSodaConnection.m
@@ -86,6 +86,7 @@ static NSString *const kBlankUUID = @"00000000-0000-0000-0000-000000000000";
         _shellAuthService = shellAuthService;
         _credentialClient = [clientFactory credentialClientWithConnection:self];
         _authQueue = dispatch_queue_create("MHVSodaConnection.authQueue", DISPATCH_QUEUE_SERIAL);
+        [self setConnectionPropertiesFromKeychain];
     }
     
     return self;


### PR DESCRIPTION
Many cases require the HealthVault connection to be ready as soon as the app launches (push notifications, system notifications, local notifications, background fetch, etc.) . This change sets the credentials on the connection when the connection is initialized rather than waiting for a call to authenticate. If the connection was not authenticated in a previous session, nothing will happen.