### PR TITLE
Add BaseURL and Header options to MHVRestRequest

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - EncryptedCoreData (3.1):
     - SQLCipher (~> 3.4.0)
-  - HealthVault (3.0-preview.5):
-    - HealthVault/CachingSupport (= 3.0-preview.5)
-  - HealthVault/CachingSupport (3.0-preview.5):
+  - HealthVault (3.0-preview.6):
+    - HealthVault/CachingSupport (= 3.0-preview.6)
+  - HealthVault/CachingSupport (3.0-preview.6):
     - EncryptedCoreData (~> 3.1)
-  - HealthVault/Tests (3.0-preview.5):
+  - HealthVault/Tests (3.0-preview.6):
     - EncryptedCoreData (~> 3.1)
   - Kiwi (2.4.0)
   - SQLCipher (3.4.1):
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   EncryptedCoreData: f6762fb05f88a52f36c5648659abc91b57f244b4
-  HealthVault: 7769453ba55849e8360625284fdc87764464841b
+  HealthVault: da21e6c8ef249e9e06e8536a440ebd7e4243b1e4
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
   SQLCipher: 43d12c0eb9c57fb438749618fc3ce0065509a559
 

--- a/Example/Pods/Local Podspecs/HealthVault.podspec.json
+++ b/Example/Pods/Local Podspecs/HealthVault.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "HealthVault",
-  "version": "3.0-preview.5",
+  "version": "3.0-preview.6",
   "summary": "An iOS framework you can use to build applications that leverage the Microsoft HealthVault platform",
   "description": "The healthvault-ios-sdk framework simplifies developing apps that use the Microsoft HealthVault platform. It handles authenticating users, managing credentials, serializing data types and much more.",
   "homepage": "https://github.com/Microsoft/healthvault-ios-sdk",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/Microsoft/healthvault-ios-sdk.git",
-    "tag": "3.0-preview.5"
+    "tag": "3.0-preview.6"
   },
   "platforms": {
     "ios": "8.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,11 +1,11 @@
 PODS:
   - EncryptedCoreData (3.1):
     - SQLCipher (~> 3.4.0)
-  - HealthVault (3.0-preview.5):
-    - HealthVault/CachingSupport (= 3.0-preview.5)
-  - HealthVault/CachingSupport (3.0-preview.5):
+  - HealthVault (3.0-preview.6):
+    - HealthVault/CachingSupport (= 3.0-preview.6)
+  - HealthVault/CachingSupport (3.0-preview.6):
     - EncryptedCoreData (~> 3.1)
-  - HealthVault/Tests (3.0-preview.5):
+  - HealthVault/Tests (3.0-preview.6):
     - EncryptedCoreData (~> 3.1)
   - Kiwi (2.4.0)
   - SQLCipher (3.4.1):
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   EncryptedCoreData: f6762fb05f88a52f36c5648659abc91b57f244b4
-  HealthVault: 7769453ba55849e8360625284fdc87764464841b
+  HealthVault: da21e6c8ef249e9e06e8536a440ebd7e4243b1e4
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
   SQLCipher: 43d12c0eb9c57fb438749618fc3ce0065509a559
 

--- a/Example/Tests/Connection/MHVConnectionTests.m
+++ b/Example/Tests/Connection/MHVConnectionTests.m
@@ -271,6 +271,7 @@ describe(@"MHVConnectionTests", ^
                                                                             httpMethod:@"METHOD"
                                                                             pathParams:nil
                                                                            queryParams:@{ @"query1" : @"ABC" }
+                                                                               headers:nil
                                                                                   body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
                                                                            isAnonymous:NO];
                     
@@ -316,6 +317,7 @@ describe(@"MHVConnectionTests", ^
                                                                             httpMethod:@"METHOD"
                                                                             pathParams:nil
                                                                            queryParams:@{ @"query1" : @"ABC" }
+                                                                               headers:nil
                                                                                   body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
                                                                            isAnonymous:YES];
                     
@@ -383,6 +385,7 @@ describe(@"MHVConnectionTests", ^
                                                                             httpMethod:@"METHOD"
                                                                             pathParams:nil
                                                                            queryParams:@{ @"query1" : @"ABC" }
+                                                                               headers:nil
                                                                                   body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
                                                                            isAnonymous:NO];
                     
@@ -476,6 +479,7 @@ describe(@"MHVConnectionTests", ^
                                                                             httpMethod:@"METHOD"
                                                                             pathParams:nil
                                                                            queryParams:@{ @"query1" : @"ABC" }
+                                                                               headers:nil
                                                                                   body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
                                                                            isAnonymous:NO];
                     [testConnection executeHttpServiceOperation:restRequest
@@ -550,6 +554,7 @@ describe(@"MHVConnectionTests", ^
                                                                             httpMethod:@"METHOD"
                                                                             pathParams:nil
                                                                            queryParams:@{ @"query1" : @"ABC" }
+                                                                               headers:nil
                                                                                   body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
                                                                            isAnonymous:YES];
                     [testConnection executeHttpServiceOperation:restRequest
@@ -571,6 +576,33 @@ describe(@"MHVConnectionTests", ^
                 it(@"Should get correct results", ^
                    {
                        [[expectFutureValue([[NSString alloc] initWithData:resultResponse.responseData encoding:NSUTF8StringEncoding]) shouldEventually] equal:@"ABCDEFG"];
+                   });
+            });
+    
+    context(@"MHVRestRequest with custom headers", ^
+            {
+                beforeEach(^{
+                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:@"path"
+                                                                            httpMethod:@"METHOD"
+                                                                            pathParams:nil
+                                                                           queryParams:nil
+                                                                               headers:@{ @"Authorization" : @"TOKEN abcdef" }
+                                                                                  body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
+                                                                           isAnonymous:NO];
+                    
+                    [testConnection executeHttpServiceOperation:restRequest
+                                                     completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error) { }];
+                });
+                
+                it(@"sendRequest should have been performed", ^
+                   {
+                       [[expectFutureValue(requestedURL) shouldEventually] beKindOfClass:[NSURL class]];
+                   });
+                
+                it(@"custom authorization header should be set", ^
+                   {
+                       [[expectFutureValue(requestedHeaders) shouldEventually] beNonNil];
+                       [[expectFutureValue(requestedHeaders[@"Authorization"]) shouldEventually] equal:@"TOKEN abcdef"];
                    });
             });
     

--- a/Example/Tests/Connection/MHVConnectionTests.m
+++ b/Example/Tests/Connection/MHVConnectionTests.m
@@ -267,13 +267,14 @@ describe(@"MHVConnectionTests", ^
     context(@"MHVRestRequest not anonymous", ^
             {
                 beforeEach(^{
-                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:@"path"
-                                                                            httpMethod:@"METHOD"
-                                                                            pathParams:nil
-                                                                           queryParams:@{ @"query1" : @"ABC" }
-                                                                               headers:nil
-                                                                                  body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
-                                                                           isAnonymous:NO];
+                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithBaseUrl:nil
+                                                                                     path:@"path"
+                                                                               httpMethod:@"METHOD"
+                                                                               pathParams:nil
+                                                                              queryParams:@{ @"query1" : @"ABC" }
+                                                                                  headers:nil
+                                                                                     body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
+                                                                              isAnonymous:NO];
                     
                     [testConnection executeHttpServiceOperation:restRequest
                                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error) { }];
@@ -313,13 +314,14 @@ describe(@"MHVConnectionTests", ^
     context(@"MHVRestRequest anonymous", ^
             {
                 beforeEach(^{
-                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:@"path"
-                                                                            httpMethod:@"METHOD"
-                                                                            pathParams:nil
-                                                                           queryParams:@{ @"query1" : @"ABC" }
-                                                                               headers:nil
-                                                                                  body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
-                                                                           isAnonymous:YES];
+                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithBaseUrl:nil
+                                                                                     path:@"path"
+                                                                               httpMethod:@"METHOD"
+                                                                               pathParams:nil
+                                                                              queryParams:@{ @"query1" : @"ABC" }
+                                                                                  headers:nil
+                                                                                     body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
+                                                                              isAnonymous:YES];
                     
                     [testConnection executeHttpServiceOperation:restRequest
                                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error) { }];
@@ -381,13 +383,14 @@ describe(@"MHVConnectionTests", ^
                          return nil;
                      }];
                     
-                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:@"path"
-                                                                            httpMethod:@"METHOD"
-                                                                            pathParams:nil
-                                                                           queryParams:@{ @"query1" : @"ABC" }
-                                                                               headers:nil
-                                                                                  body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
-                                                                           isAnonymous:NO];
+                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithBaseUrl:nil
+                                                                                     path:@"path"
+                                                                               httpMethod:@"METHOD"
+                                                                               pathParams:nil
+                                                                              queryParams:@{ @"query1" : @"ABC" }
+                                                                                  headers:nil
+                                                                                     body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
+                                                                              isAnonymous:NO];
                     
                     [testConnection executeHttpServiceOperation:restRequest
                                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error) { }];
@@ -475,13 +478,14 @@ describe(@"MHVConnectionTests", ^
                     NSString *nilToken = nil;
                     testConnection.sessionCredential = [[MHVSessionCredential alloc] initWithToken:nilToken sharedSecret:kDefaultSharedSecret];
                     
-                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:@"path"
-                                                                            httpMethod:@"METHOD"
-                                                                            pathParams:nil
-                                                                           queryParams:@{ @"query1" : @"ABC" }
-                                                                               headers:nil
-                                                                                  body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
-                                                                           isAnonymous:NO];
+                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithBaseUrl:nil
+                                                                                     path:@"path"
+                                                                               httpMethod:@"METHOD"
+                                                                               pathParams:nil
+                                                                              queryParams:@{ @"query1" : @"ABC" }
+                                                                                  headers:nil
+                                                                                     body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
+                                                                              isAnonymous:NO];
                     [testConnection executeHttpServiceOperation:restRequest
                                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
                      {
@@ -550,13 +554,14 @@ describe(@"MHVConnectionTests", ^
                     requestCompletionResponse = [[MHVHttpServiceResponse alloc] initWithResponseData:[@"ABCDEFG" dataUsingEncoding:NSUTF8StringEncoding]
                                                                                           statusCode:0];
                     
-                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:@"path"
-                                                                            httpMethod:@"METHOD"
-                                                                            pathParams:nil
-                                                                           queryParams:@{ @"query1" : @"ABC" }
-                                                                               headers:nil
-                                                                                  body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
-                                                                           isAnonymous:YES];
+                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithBaseUrl:nil
+                                                                                     path:@"path"
+                                                                               httpMethod:@"METHOD"
+                                                                               pathParams:nil
+                                                                              queryParams:@{ @"query1" : @"ABC" }
+                                                                                  headers:nil
+                                                                                     body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
+                                                                              isAnonymous:YES];
                     [testConnection executeHttpServiceOperation:restRequest
                                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error)
                      {
@@ -579,33 +584,54 @@ describe(@"MHVConnectionTests", ^
                    });
             });
     
-    context(@"MHVRestRequest with custom headers", ^
+    context(@"MHVRestRequest should send custom headers", ^
             {
                 beforeEach(^{
-                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:@"path"
-                                                                            httpMethod:@"METHOD"
-                                                                            pathParams:nil
-                                                                           queryParams:nil
-                                                                               headers:@{ @"Authorization" : @"TOKEN abcdef" }
-                                                                                  body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
-                                                                           isAnonymous:NO];
+                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithBaseUrl:nil
+                                                                                     path:@"path"
+                                                                               httpMethod:@"METHOD"
+                                                                               pathParams:nil
+                                                                              queryParams:nil
+                                                                                  headers:@{ @"Authorization" : @"TOKEN abcdef",
+                                                                                             @"x-xyz" : @"12345" }
+                                                                                     body:[@"Body" dataUsingEncoding:NSUTF8StringEncoding]
+                                                                              isAnonymous:NO];
                     
                     [testConnection executeHttpServiceOperation:restRequest
                                                      completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error) { }];
                 });
                 
-                it(@"sendRequest should have been performed", ^
-                   {
-                       [[expectFutureValue(requestedURL) shouldEventually] beKindOfClass:[NSURL class]];
-                   });
-                
                 it(@"custom authorization header should be set", ^
                    {
                        [[expectFutureValue(requestedHeaders) shouldEventually] beNonNil];
                        [[expectFutureValue(requestedHeaders[@"Authorization"]) shouldEventually] equal:@"TOKEN abcdef"];
+                       [[expectFutureValue(requestedHeaders[@"x-xyz"]) shouldEventually] equal:@"12345"];
                    });
             });
-    
+
+    context(@"MHVRestRequest should combine URL and Path", ^
+            {
+                beforeEach(^{
+                    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithBaseUrl:[NSURL URLWithString:@"https://test.com/base"]
+                                                                                     path:@"path/file"
+                                                                               httpMethod:@"METHOD"
+                                                                               pathParams:nil
+                                                                              queryParams:nil
+                                                                                  headers:nil
+                                                                                     body:nil
+                                                                              isAnonymous:NO];
+                    
+                    [testConnection executeHttpServiceOperation:restRequest
+                                                     completion:^(MHVServiceResponse * _Nullable response, NSError * _Nullable error) { }];
+                });
+                
+                it(@"requestedURL should be base url plus path", ^
+                   {
+                       [[expectFutureValue(requestedURL) shouldEventually] beKindOfClass:[NSURL class]];
+                       [[expectFutureValue(requestedURL.absoluteString) shouldEventually] equal:@"https://test.com/base/path/file"];
+                   });
+            });
+
 });
 
 SPEC_END

--- a/HealthVault.podspec
+++ b/HealthVault.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'HealthVault'
-  s.version          = '3.0-preview.5'
+  s.version          = '3.0-preview.6'
   s.summary          = 'An iOS framework you can use to build applications that leverage the Microsoft HealthVault platform'
 
 

--- a/HealthVault/Classes/Clients/MHVRemoteMonitoringClient.m
+++ b/HealthVault/Classes/Clients/MHVRemoteMonitoringClient.m
@@ -52,6 +52,7 @@
              httpMethod:(NSString *_Nonnull)httpMethod
              pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
             queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                    body:(NSData *_Nullable)body
             resultClass:(Class)resultClass
              completion:(void(^_Nullable)(id _Nullable output, NSError *_Nullable error))completion
@@ -65,7 +66,7 @@
                                                             httpMethod:httpMethod
                                                             pathParams:pathParams
                                                            queryParams:queryParams
-                                                               headers:nil
+                                                               headers:headers
                                                                   body:body
                                                            isAnonymous:NO];
     
@@ -97,6 +98,7 @@
              httpMethod:(NSString *)httpMethod
              pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
             queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                    body:(NSData *_Nullable)body
              completion:(void(^_Nullable)(NSError *_Nullable error))completion;
 {
@@ -109,7 +111,7 @@
                                                             httpMethod:httpMethod
                                                             pathParams:pathParams
                                                            queryParams:queryParams
-                                                               headers:nil
+                                                               headers:headers
                                                                   body:body
                                                            isAnonymous:NO];
     

--- a/HealthVault/Classes/Clients/MHVRemoteMonitoringClient.m
+++ b/HealthVault/Classes/Clients/MHVRemoteMonitoringClient.m
@@ -65,6 +65,7 @@
                                                             httpMethod:httpMethod
                                                             pathParams:pathParams
                                                            queryParams:queryParams
+                                                               headers:nil
                                                                   body:body
                                                            isAnonymous:NO];
     
@@ -108,6 +109,7 @@
                                                             httpMethod:httpMethod
                                                             pathParams:pathParams
                                                            queryParams:queryParams
+                                                               headers:nil
                                                                   body:body
                                                            isAnonymous:NO];
     

--- a/HealthVault/Classes/Clients/MHVRemoteMonitoringClient.m
+++ b/HealthVault/Classes/Clients/MHVRemoteMonitoringClient.m
@@ -48,27 +48,29 @@
     return self;
 }
 
-- (void)requestWithPath:(NSString *_Nonnull)path
-             httpMethod:(NSString *_Nonnull)httpMethod
-             pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
-            queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
-                headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
-                   body:(NSData *_Nullable)body
-            resultClass:(Class)resultClass
-             completion:(void(^_Nullable)(id _Nullable output, NSError *_Nullable error))completion
+- (void)requestWithBaseUrl:(NSURL *_Nullable)url
+                      path:(NSString *_Nonnull)path
+                httpMethod:(NSString *_Nonnull)httpMethod
+                pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+               queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                   headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
+                      body:(NSData *_Nullable)body
+               resultClass:(Class)resultClass
+                completion:(void(^_Nullable)(id _Nullable output, NSError *_Nullable error))completion
 {
     MHVASSERT_PARAMETER(path);
     MHVASSERT_PARAMETER(httpMethod);
     
     path = [self updatePath:path pathParams:pathParams];
     
-    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:path
-                                                            httpMethod:httpMethod
-                                                            pathParams:pathParams
-                                                           queryParams:queryParams
-                                                               headers:headers
-                                                                  body:body
-                                                           isAnonymous:NO];
+    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithBaseUrl:url
+                                                                     path:path
+                                                               httpMethod:httpMethod
+                                                               pathParams:pathParams
+                                                              queryParams:queryParams
+                                                                  headers:headers
+                                                                     body:body
+                                                              isAnonymous:NO];
     
     [self.connection executeHttpServiceOperation:restRequest
                                       completion:^(MHVServiceResponse *_Nullable response, NSError *_Nullable error)
@@ -94,26 +96,28 @@
      }];
 }
 
-- (void)requestWithPath:(NSString *)path
-             httpMethod:(NSString *)httpMethod
-             pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
-            queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
-                headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
-                   body:(NSData *_Nullable)body
-             completion:(void(^_Nullable)(NSError *_Nullable error))completion;
+- (void)requestWithBaseUrl:(NSURL *_Nullable)url
+                      path:(NSString *)path
+                httpMethod:(NSString *)httpMethod
+                pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+               queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                   headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
+                      body:(NSData *_Nullable)body
+                completion:(void(^_Nullable)(NSError *_Nullable error))completion;
 {
     MHVASSERT_PARAMETER(path);
     MHVASSERT_PARAMETER(httpMethod);
     
     path = [self updatePath:path pathParams:pathParams];
     
-    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithPath:path
-                                                            httpMethod:httpMethod
-                                                            pathParams:pathParams
-                                                           queryParams:queryParams
-                                                               headers:headers
-                                                                  body:body
-                                                           isAnonymous:NO];
+    MHVRestRequest *restRequest = [[MHVRestRequest alloc] initWithBaseUrl:url
+                                                                     path:path
+                                                               httpMethod:httpMethod
+                                                               pathParams:pathParams
+                                                              queryParams:queryParams
+                                                                  headers:headers
+                                                                     body:body
+                                                              isAnonymous:NO];
     
     [self.connection executeHttpServiceOperation:restRequest
                                       completion:^(MHVServiceResponse *_Nullable response, NSError *_Nullable error)

--- a/HealthVault/Classes/Clients/MHVRemoteMonitoringClientProtocol.h
+++ b/HealthVault/Classes/Clients/MHVRemoteMonitoringClientProtocol.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
              httpMethod:(NSString *)httpMethod
              pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
             queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                    body:(NSData *_Nullable)body
             resultClass:(Class)resultClass
              completion:(void(^_Nullable)(id _Nullable output, NSError *_Nullable error))completion;
@@ -58,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
              httpMethod:(NSString *)httpMethod
              pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
             queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                    body:(NSData *_Nullable)body
              completion:(void(^_Nullable)(NSError *_Nullable error))completion;
 

--- a/HealthVault/Classes/Clients/MHVRemoteMonitoringClientProtocol.h
+++ b/HealthVault/Classes/Clients/MHVRemoteMonitoringClientProtocol.h
@@ -26,7 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Performs a request
  *
- * @param path Request url.
+ * @param baseUrl Base URL, path parameter will be appended to this.  If nil the URL will be generated from the service URL
+ * @param path Request path.
  * @param httpMethod Request method, "GET", "POST", "PATCH", etc
  * @param pathParams Request path parameters.  Values in {brackets} in the path will be replaced by values from this dictionary
  *        pathParams { @"date" : @"2017-05-23" } with path @"endDate={date}" would result in @"endDate=2017-05-23"
@@ -35,19 +36,21 @@ NS_ASSUME_NONNULL_BEGIN
  * @param resultClass the class the response should be deserialized to.
  * @param completion The block will be executed when the request completed.
  */
-- (void)requestWithPath:(NSString *)path
-             httpMethod:(NSString *)httpMethod
-             pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
-            queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
-                headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
-                   body:(NSData *_Nullable)body
-            resultClass:(Class)resultClass
-             completion:(void(^_Nullable)(id _Nullable output, NSError *_Nullable error))completion;
+- (void)requestWithBaseUrl:(NSURL *_Nullable)baseUrl
+                      path:(NSString *)path
+                httpMethod:(NSString *)httpMethod
+                pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+               queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                   headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
+                      body:(NSData *_Nullable)body
+               resultClass:(Class)resultClass
+                completion:(void(^_Nullable)(id _Nullable output, NSError *_Nullable error))completion;
 
 /**
  * Performs a request and does not expect a response object
  *
- * @param path Request url.
+ * @param baseUrl Base URL, path parameter will be appended to this.  If nil the URL will be generated from the service URL
+ * @param path Request path.
  * @param httpMethod Request method, "DELETE", etc.
  * @param pathParams Request path parameters.  Values in {brackets} in the path will be replaced by values from this dictionary
  *        pathParams { @"date" : @"2017-05-23" } with path @"endDate={date}" would result in @"endDate=2017-05-23"
@@ -55,13 +58,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @param body Request body.
  * @param completion The block will be executed when the request completed.
  */
-- (void)requestWithPath:(NSString *)path
-             httpMethod:(NSString *)httpMethod
-             pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
-            queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
-                headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
-                   body:(NSData *_Nullable)body
-             completion:(void(^_Nullable)(NSError *_Nullable error))completion;
+- (void)requestWithBaseUrl:(NSURL *_Nullable)baseUrl
+                      path:(NSString *)path
+                httpMethod:(NSString *)httpMethod
+                pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+               queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                   headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
+                      body:(NSData *_Nullable)body
+                completion:(void(^_Nullable)(NSError *_Nullable error))completion;
 
 @end
 

--- a/HealthVault/Classes/Connection/Private/MHVConnection.m
+++ b/HealthVault/Classes/Connection/Private/MHVConnection.m
@@ -308,10 +308,17 @@ static NSInteger kInternalServerError = 500;
     
     MHVLOG(@"Execute Request: %@", restRequest.path);
 
-    // If no URL is set, build it from serviceInstance
+    // If no URL is set, build it from serviceInstance or BaseUrl
     if (!restRequest.url)
     {
-        [restRequest updateUrlWithServiceUrl:self.configuration.restHealthVaultUrl];
+        if (restRequest.baseUrl)
+        {
+            [restRequest updateUrlFromBaseUrl];
+        }
+        else
+        {
+            [restRequest updateUrlWithServiceUrl:self.configuration.restHealthVaultUrl];
+        }
     }
     
     // Add authorization header

--- a/HealthVault/Classes/Connection/Private/MHVConnection.m
+++ b/HealthVault/Classes/Connection/Private/MHVConnection.m
@@ -328,6 +328,12 @@ static NSInteger kInternalServerError = 500;
     headers[@"version"] = [MHVClientInfo telemetryInfo];
     
     headers[@"Content-Type"] = @"application/json";
+    
+    // Add extra headers from restRequest; last so it can override other header values
+    if (restRequest.headers.count > 0)
+    {
+        [headers addEntriesFromDictionary:restRequest.headers];
+    }
 
     [self.httpService sendRequestForURL:restRequest.url
                              httpMethod:restRequest.httpMethod

--- a/HealthVault/Classes/Models/Generated/Categories/MHVActionPlanTasksApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVActionPlanTasksApi.m
@@ -74,7 +74,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"POST"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -119,7 +119,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-			    	    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"DELETE"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -149,7 +149,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -194,7 +194,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -237,7 +237,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"PUT"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -280,7 +280,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"PATCH"
                   pathParams:pathParams
                  queryParams:queryParams

--- a/HealthVault/Classes/Models/Generated/Categories/MHVActionPlanTasksApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVActionPlanTasksApi.m
@@ -73,14 +73,15 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:actionPlanTask];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"POST"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanTaskInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"POST"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanTaskInstance class]
+                  completion:completion];
 }
 
 ///
@@ -117,13 +118,14 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"DELETE"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                         headers:nil
-                            body:bodyParam
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+			    	    path:resourcePath
+                  httpMethod:@"DELETE"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                  completion:completion];
 }
 
 ///
@@ -146,14 +148,15 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanTasksResponseActionPlanTaskInstance_ class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanTasksResponseActionPlanTaskInstance_ class]
+                  completion:completion];
 }
 
 ///
@@ -190,14 +193,15 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanTaskInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanTaskInstance class]
+                  completion:completion];
 }
 
 ///
@@ -232,14 +236,15 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:actionPlanTask];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"PUT"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanTaskInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"PUT"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanTaskInstance class]
+                  completion:completion];
 }
 
 ///
@@ -274,14 +279,15 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:actionPlanTask];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"PATCH"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanTaskInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"PATCH"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanTaskInstance class]
+                  completion:completion];
 }
 
 

--- a/HealthVault/Classes/Models/Generated/Categories/MHVActionPlanTasksApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVActionPlanTasksApi.m
@@ -77,6 +77,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
                       httpMethod:@"POST"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanTaskInstance class]
                       completion:completion];
@@ -120,6 +121,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
                       httpMethod:@"DELETE"
                       pathParams:pathParams
                      queryParams:queryParams
+                         headers:nil
                             body:bodyParam
                       completion:completion];
 }
@@ -148,6 +150,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanTasksResponseActionPlanTaskInstance_ class]
                       completion:completion];
@@ -191,6 +194,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanTaskInstance class]
                       completion:completion];
@@ -232,6 +236,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
                       httpMethod:@"PUT"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanTaskInstance class]
                       completion:completion];
@@ -273,6 +278,7 @@ NSInteger kMHVActionPlanTasksApiMissingParamErrorCode = 234513;
                       httpMethod:@"PATCH"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanTaskInstance class]
                       completion:completion];

--- a/HealthVault/Classes/Models/Generated/Categories/MHVActionPlansApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVActionPlansApi.m
@@ -97,7 +97,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-			    	    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"DELETE"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -139,7 +139,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"POST"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -184,7 +184,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-			    	    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"DELETE"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -209,7 +209,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -306,7 +306,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -351,7 +351,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -394,7 +394,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"PUT"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -437,7 +437,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"PATCH"
                   pathParams:pathParams
                  queryParams:queryParams

--- a/HealthVault/Classes/Models/Generated/Categories/MHVActionPlansApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVActionPlansApi.m
@@ -100,6 +100,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
                       httpMethod:@"DELETE"
                       pathParams:pathParams
                      queryParams:queryParams
+                         headers:nil
                             body:bodyParam
                       completion:completion];
 }
@@ -140,6 +141,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
                       httpMethod:@"POST"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanInstance class]
                       completion:completion];
@@ -183,6 +185,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
                       httpMethod:@"DELETE"
                       pathParams:pathParams
                      queryParams:queryParams
+                         headers:nil
                             body:bodyParam
                       completion:completion];
 }
@@ -206,6 +209,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlansResponseActionPlanInstance_ class]
                       completion:completion];
@@ -301,6 +305,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanAdherenceSummary class]
                       completion:completion];
@@ -344,6 +349,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanInstance class]
                       completion:completion];
@@ -385,6 +391,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
                       httpMethod:@"PUT"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanInstance class]
                       completion:completion];
@@ -426,6 +433,7 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
                       httpMethod:@"PATCH"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanInstance class]
                       completion:completion];

--- a/HealthVault/Classes/Models/Generated/Categories/MHVActionPlansApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVActionPlansApi.m
@@ -96,13 +96,14 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"DELETE"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                         headers:nil
-                            body:bodyParam
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+			    	    path:resourcePath
+                  httpMethod:@"DELETE"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                  completion:completion];
 }
 
 ///
@@ -137,14 +138,15 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:actionPlan];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"POST"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"POST"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanInstance class]
+                  completion:completion];
 }
 
 ///
@@ -181,13 +183,14 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"DELETE"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                         headers:nil
-                            body:bodyParam
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+			    	    path:resourcePath
+                  httpMethod:@"DELETE"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                  completion:completion];
 }
 
 ///
@@ -205,14 +208,15 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlansResponseActionPlanInstance_ class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlansResponseActionPlanInstance_ class]
+                  completion:completion];
 }
 
 ///
@@ -301,14 +305,15 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanAdherenceSummary class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanAdherenceSummary class]
+                  completion:completion];
 }
 
 ///
@@ -345,14 +350,15 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanInstance class]
+                  completion:completion];
 }
 
 ///
@@ -387,14 +393,15 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:actionPlan];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"PUT"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"PUT"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanInstance class]
+                  completion:completion];
 }
 
 ///
@@ -429,14 +436,15 @@ NSInteger kMHVActionPlansApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:actionPlan];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"PATCH"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"PATCH"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanInstance class]
+                  completion:completion];
 }
 
 

--- a/HealthVault/Classes/Models/Generated/Categories/MHVGoalsApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVGoalsApi.m
@@ -77,6 +77,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
                       httpMethod:@"POST"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVGoalsResponse class]
                       completion:completion];
@@ -120,6 +121,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
                       httpMethod:@"DELETE"
                       pathParams:pathParams
                      queryParams:queryParams
+                         headers:nil
                             body:bodyParam
                       completion:completion];
 }
@@ -166,6 +168,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVGoalsResponse class]
                       completion:completion];
@@ -201,6 +204,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVGoalsResponse class]
                       completion:completion];
@@ -244,6 +248,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVGoal class]
                       completion:completion];
@@ -285,6 +290,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
                       httpMethod:@"PUT"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVGoal class]
                       completion:completion];
@@ -326,6 +332,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
                       httpMethod:@"PATCH"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVGoalsResponse class]
                       completion:completion];

--- a/HealthVault/Classes/Models/Generated/Categories/MHVGoalsApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVGoalsApi.m
@@ -74,7 +74,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"POST"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -119,7 +119,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-			    	    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"DELETE"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -167,7 +167,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -204,7 +204,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -249,7 +249,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -292,7 +292,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"PUT"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -335,7 +335,7 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"PATCH"
                   pathParams:pathParams
                  queryParams:queryParams

--- a/HealthVault/Classes/Models/Generated/Categories/MHVGoalsApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVGoalsApi.m
@@ -73,14 +73,15 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:goalsWrapper];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"POST"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVGoalsResponse class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"POST"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVGoalsResponse class]
+                  completion:completion];
 }
 
 ///
@@ -117,13 +118,14 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"DELETE"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                         headers:nil
-                            body:bodyParam
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+			    	    path:resourcePath
+                  httpMethod:@"DELETE"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                  completion:completion];
 }
 
 ///
@@ -164,14 +166,15 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVGoalsResponse class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVGoalsResponse class]
+                  completion:completion];
 }
 
 ///
@@ -200,14 +203,15 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVGoalsResponse class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVGoalsResponse class]
+                  completion:completion];
 }
 
 ///
@@ -244,14 +248,15 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVGoal class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVGoal class]
+                  completion:completion];
 }
 
 ///
@@ -286,14 +291,15 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:goal];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"PUT"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVGoal class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"PUT"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVGoal class]
+                  completion:completion];
 }
 
 ///
@@ -328,14 +334,15 @@ NSInteger kMHVGoalsApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:goalsWrapper];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"PATCH"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVGoalsResponse class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"PATCH"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVGoalsResponse class]
+                  completion:completion];
 }
 
 

--- a/HealthVault/Classes/Models/Generated/Categories/MHVGoalsRecommendationsApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVGoalsRecommendationsApi.m
@@ -76,7 +76,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-			    	    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"PUT"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -118,7 +118,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"POST"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -163,7 +163,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-			    	    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"DELETE"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -199,7 +199,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -244,7 +244,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams

--- a/HealthVault/Classes/Models/Generated/Categories/MHVGoalsRecommendationsApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVGoalsRecommendationsApi.m
@@ -79,6 +79,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
                       httpMethod:@"PUT"
                       pathParams:pathParams
                      queryParams:queryParams
+                         headers:nil
                             body:bodyParam
                       completion:completion];
 }
@@ -119,6 +120,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
                       httpMethod:@"POST"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVGoalRecommendationInstance class]
                       completion:completion];
@@ -162,6 +164,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
                       httpMethod:@"DELETE"
                       pathParams:pathParams
                      queryParams:queryParams
+                         headers:nil
                             body:bodyParam
                       completion:completion];
 }
@@ -196,6 +199,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVGoalRecommendationsResponse class]
                       completion:completion];
@@ -239,6 +243,7 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVGoalRecommendationInstance class]
                       completion:completion];

--- a/HealthVault/Classes/Models/Generated/Categories/MHVGoalsRecommendationsApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVGoalsRecommendationsApi.m
@@ -75,13 +75,14 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"PUT"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                         headers:nil
-                            body:bodyParam
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+			    	    path:resourcePath
+                  httpMethod:@"PUT"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                  completion:completion];
 }
 
 ///
@@ -116,14 +117,15 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:goalRecommendation];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"POST"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVGoalRecommendationInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"POST"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVGoalRecommendationInstance class]
+                  completion:completion];
 }
 
 ///
@@ -160,13 +162,14 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"DELETE"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                         headers:nil
-                            body:bodyParam
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+			    	    path:resourcePath
+                  httpMethod:@"DELETE"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                  completion:completion];
 }
 
 ///
@@ -195,14 +198,15 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVGoalRecommendationsResponse class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVGoalRecommendationsResponse class]
+                  completion:completion];
 }
 
 ///
@@ -239,14 +243,15 @@ NSInteger kMHVGoalsRecommendationsApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVGoalRecommendationInstance class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVGoalRecommendationInstance class]
+                  completion:completion];
 }
 
 

--- a/HealthVault/Classes/Models/Generated/Categories/MHVTaskTrackingApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVTaskTrackingApi.m
@@ -73,14 +73,15 @@ NSInteger kMHVTaskTrackingApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"DELETE"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[NSNumber class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"DELETE"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[NSNumber class]
+                  completion:completion];
 }
 
 ///
@@ -135,14 +136,15 @@ NSInteger kMHVTaskTrackingApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:taskTrackingOccurrence];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"PATCH"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVTaskTrackingOccurrence class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"PATCH"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVTaskTrackingOccurrence class]
+                  completion:completion];
 }
 
 ///
@@ -177,14 +179,15 @@ NSInteger kMHVTaskTrackingApiMissingParamErrorCode = 234513;
     NSString *json = [MHVJsonSerializer serialize:taskTrackingOccurrence];
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"POST"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVTaskTrackingOccurrence class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"POST"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVTaskTrackingOccurrence class]
+                  completion:completion];
 }
 
 

--- a/HealthVault/Classes/Models/Generated/Categories/MHVTaskTrackingApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVTaskTrackingApi.m
@@ -74,7 +74,7 @@ NSInteger kMHVTaskTrackingApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"DELETE"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -137,7 +137,7 @@ NSInteger kMHVTaskTrackingApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"PATCH"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -180,7 +180,7 @@ NSInteger kMHVTaskTrackingApiMissingParamErrorCode = 234513;
     bodyParam = [json dataUsingEncoding:NSUTF8StringEncoding];
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"POST"
                   pathParams:pathParams
                  queryParams:queryParams

--- a/HealthVault/Classes/Models/Generated/Categories/MHVTaskTrackingApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVTaskTrackingApi.m
@@ -77,6 +77,7 @@ NSInteger kMHVTaskTrackingApiMissingParamErrorCode = 234513;
                       httpMethod:@"DELETE"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[NSNumber class]
                       completion:completion];
@@ -138,6 +139,7 @@ NSInteger kMHVTaskTrackingApiMissingParamErrorCode = 234513;
                       httpMethod:@"PATCH"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVTaskTrackingOccurrence class]
                       completion:completion];
@@ -179,6 +181,7 @@ NSInteger kMHVTaskTrackingApiMissingParamErrorCode = 234513;
                       httpMethod:@"POST"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVTaskTrackingOccurrence class]
                       completion:completion];

--- a/HealthVault/Classes/Models/Generated/Categories/MHVTimelineApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVTimelineApi.m
@@ -116,6 +116,7 @@ NSInteger kMHVTimelineApiMissingParamErrorCode = 234513;
                       httpMethod:@"GET"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[MHVActionPlanTasksResponseTimelineTask_ class]
                       completion:completion];

--- a/HealthVault/Classes/Models/Generated/Categories/MHVTimelineApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVTimelineApi.m
@@ -112,14 +112,15 @@ NSInteger kMHVTimelineApiMissingParamErrorCode = 234513;
 
     NSData *bodyParam = nil;
 
-    [self requestWithPath:resourcePath
-                      httpMethod:@"GET"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[MHVActionPlanTasksResponseTimelineTask_ class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"GET"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[MHVActionPlanTasksResponseTimelineTask_ class]
+                  completion:completion];
 }
 
 

--- a/HealthVault/Classes/Models/Generated/Categories/MHVTimelineApi.m
+++ b/HealthVault/Classes/Models/Generated/Categories/MHVTimelineApi.m
@@ -113,7 +113,7 @@ NSInteger kMHVTimelineApiMissingParamErrorCode = 234513;
     NSData *bodyParam = nil;
 
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"GET"
                   pathParams:pathParams
                  queryParams:queryParams

--- a/HealthVault/Classes/Private/Methods/MHVRestRequest.h
+++ b/HealthVault/Classes/Private/Methods/MHVRestRequest.h
@@ -33,16 +33,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly)           BOOL          isAnonymous;
 
 @property (nonatomic, strong, readonly)           NSURL         *url;
+@property (nonatomic, strong, readonly)           NSURL         *baseUrl;
 
-- (instancetype)initWithPath:(NSString *)path
-                  httpMethod:(NSString *)httpMethod
-                  pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
-                 queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
-                     headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
-                        body:(NSData *_Nullable)body
-                 isAnonymous:(BOOL)isAnonymous;
+- (instancetype)initWithBaseUrl:(NSURL *_Nullable)baseUrl
+                           path:(NSString *)path
+                     httpMethod:(NSString *)httpMethod
+                     pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
+                    queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                        headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
+                           body:(NSData *_Nullable)body
+                    isAnonymous:(BOOL)isAnonymous;
 
 - (void)updateUrlWithServiceUrl:(NSURL *)serviceUrl;
+- (void)updateUrlFromBaseUrl;
 
 @end
 

--- a/HealthVault/Classes/Private/Methods/MHVRestRequest.h
+++ b/HealthVault/Classes/Private/Methods/MHVRestRequest.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly)           NSString      *httpMethod;
 @property (nonatomic, strong, readonly, nullable) NSDictionary  *pathParams;
 @property (nonatomic, strong, readonly, nullable) NSDictionary  *queryParams;
+@property (nonatomic, strong, readonly, nullable) NSDictionary  *headers;
 @property (nonatomic, strong, readonly, nullable) id            body;
 @property (nonatomic, assign, readonly)           BOOL          isAnonymous;
 
@@ -37,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
                   httpMethod:(NSString *)httpMethod
                   pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
                  queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                     headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                         body:(NSData *_Nullable)body
                  isAnonymous:(BOOL)isAnonymous;
 

--- a/HealthVault/Classes/Private/Methods/MHVRestRequest.m
+++ b/HealthVault/Classes/Private/Methods/MHVRestRequest.m
@@ -31,6 +31,7 @@
                   httpMethod:(NSString *)httpMethod
                   pathParams:(NSDictionary<NSString *, NSString *> *_Nullable)pathParams
                  queryParams:(NSDictionary<NSString *, NSString *> *_Nullable)queryParams
+                     headers:(NSDictionary<NSString *, NSString *> *_Nullable)headers
                         body:(NSData *_Nullable)body
                  isAnonymous:(BOOL)isAnonymous
 {
@@ -44,6 +45,7 @@
         _httpMethod = httpMethod;
         _pathParams = pathParams;
         _queryParams = queryParams;
+        _headers = headers;
         _body = body;
         _isAnonymous = isAnonymous;
     }

--- a/HealthVault/Tools/codegen/template/api-body.mustache
+++ b/HealthVault/Tools/codegen/template/api-body.mustache
@@ -80,6 +80,7 @@ NSInteger k{{classname}}MissingParamErrorCode = 234513;
                       httpMethod:@"{{httpMethod}}"
                       pathParams:pathParams
                      queryParams:queryParams
+                        headers:nil
                             body:bodyParam
                      resultClass:[{{{returnBaseType}}} class]
                       completion:completion];
@@ -89,6 +90,7 @@ NSInteger k{{classname}}MissingParamErrorCode = 234513;
                       httpMethod:@"{{httpMethod}}"
                       pathParams:pathParams
                      queryParams:queryParams
+                         headers:nil
                             body:bodyParam
                       completion:completion];
     {{/returnBaseType}}

--- a/HealthVault/Tools/codegen/template/api-body.mustache
+++ b/HealthVault/Tools/codegen/template/api-body.mustache
@@ -77,7 +77,7 @@ NSInteger k{{classname}}MissingParamErrorCode = 234513;
 
     {{#returnBaseType}}
     [self requestWithBaseUrl:nil
-		    		    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"{{httpMethod}}"
                   pathParams:pathParams
                  queryParams:queryParams
@@ -88,7 +88,7 @@ NSInteger k{{classname}}MissingParamErrorCode = 234513;
     {{/returnBaseType}}
     {{^returnBaseType}}
     [self requestWithBaseUrl:nil
-			    	    path:resourcePath
+                        path:resourcePath
                   httpMethod:@"{{httpMethod}}"
                   pathParams:pathParams
                  queryParams:queryParams

--- a/HealthVault/Tools/codegen/template/api-body.mustache
+++ b/HealthVault/Tools/codegen/template/api-body.mustache
@@ -76,23 +76,25 @@ NSInteger k{{classname}}MissingParamErrorCode = 234513;
     {{/bodyParam}}
 
     {{#returnBaseType}}
-    [self requestWithPath:resourcePath
-                      httpMethod:@"{{httpMethod}}"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                        headers:nil
-                            body:bodyParam
-                     resultClass:[{{{returnBaseType}}} class]
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+		    		    path:resourcePath
+                  httpMethod:@"{{httpMethod}}"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                 resultClass:[{{{returnBaseType}}} class]
+                  completion:completion];
     {{/returnBaseType}}
     {{^returnBaseType}}
-    [self requestWithPath:resourcePath
-                      httpMethod:@"{{httpMethod}}"
-                      pathParams:pathParams
-                     queryParams:queryParams
-                         headers:nil
-                            body:bodyParam
-                      completion:completion];
+    [self requestWithBaseUrl:nil
+			    	    path:resourcePath
+                  httpMethod:@"{{httpMethod}}"
+                  pathParams:pathParams
+                 queryParams:queryParams
+                     headers:nil
+                        body:bodyParam
+                  completion:completion];
     {{/returnBaseType}}
 }
 


### PR DESCRIPTION
Add BaseURL and Header options to MHVRestRequest, so it can be used by HealthBot swagger generated code that has different authorization/endpoints 